### PR TITLE
Remove unnecessary types-pillow

### DIFF
--- a/services/worker/poetry.lock
+++ b/services/worker/poetry.lock
@@ -3873,17 +3873,6 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
-name = "types-pillow"
-version = "9.5.0.4"
-description = "Typing stubs for Pillow"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-Pillow-9.5.0.4.tar.gz", hash = "sha256:f1b6af47abd151847ee25911ffeba784899bc7dc7f9eba8ca6a5aac522b012ef"},
-    {file = "types_Pillow-9.5.0.4-py3-none-any.whl", hash = "sha256:69427d9fa4320ff6e30f00fb9c0dd71185dc0a16de4757774220104759483466"},
-]
-
-[[package]]
 name = "types-psutil"
 version = "5.9.5.13"
 description = "Typing stubs for psutil"
@@ -4367,4 +4356,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.18"
-content-hash = "8248dd6bf4ded774c9342681c0575010252d48d1e51d80895b05aa02af4d437a"
+content-hash = "231172bc3707f0b4fc6b80318f1163a5eaff32db7648cc32b66e1a25ab632bf8"

--- a/services/worker/pyproject.toml
+++ b/services/worker/pyproject.toml
@@ -38,7 +38,6 @@ pip-audit = "^2.5.4"
 pytest = "^7.2.1"
 pytest-asyncio = "^0.21.0"
 ruff = "^0.2.1"
-types-pillow = "^9.5.0.4"
 types-psutil = "^5.9.5"
 types-requests = "^2.28.11"
 


### PR DESCRIPTION
Now that we require pillow >= 10.3.0, the package types-pillow is no longer necessary.

This PR removes it as dev dependency.