### PR TITLE
Try FTS index in local storage

### DIFF
--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -53,6 +53,13 @@ JOIN_STAGE_AND_DATA_COMMAND = (
     "SELECT data.* FROM fts_stage_table JOIN data USING(__hf_index_id) ORDER BY fts_stage_table.__hf_fts_score DESC;"
 )
 
+SPLITS_WITH_LOCAL_STORAGE = [
+    "wikimedia/wikipedia-20231101.en-train",
+    "MohamedRashad/Arabic-CivitAi-Images-default-train",
+    "jp1924/VIsualQuestionAnswering-default-train",
+    "asoria/search_test-default-train",
+]
+
 
 def full_text_search(
     index_file_location: str,
@@ -183,8 +190,13 @@ def create_search_endpoint(
                     partial = duckdb_index_is_partial(url)
 
                 with StepProfiler(method="search_endpoint", step="download index file if missing"):
+                    duckdb_index_file_downloads = (
+                        "/tmp"  # nosec - will be reverted after testing
+                        if f"{dataset}-{config}-{split}" in SPLITS_WITH_LOCAL_STORAGE
+                        else duckdb_index_file_directory
+                    )
                     index_file_location = await get_index_file_location_and_download_if_missing(
-                        duckdb_index_file_directory=duckdb_index_file_directory,
+                        duckdb_index_file_directory=duckdb_index_file_downloads,
                         dataset=dataset,
                         config=config,
                         split=split,


### PR DESCRIPTION
Before trying to change to local disks for duckdb index files, I would like to confirm whether it speeds up the response for some datasets analyzed in https://github.com/huggingface/dataset-viewer/issues/2593.

**wikimedia/wikipedia-20231101.en-train** (Medium size: 9.1 GB) =  ~17 seconds
**MohamedRashad/Arabic-CivitAi-Images - default - train** (Small size: 580 MB) =  ~4 seconds
 **jp1924/VIsualQuestionAnswering - default - train** (Big size: 23 GB) =  ~42 seconds
**asoria/search_test - default - train** (Small: 27 MB)  =  ~2 seconds

All of these indexes will occupy something like 33 GB, which is not a problem for our current pods with 40 GB free. I will manually delete after each test and then rollback.