### PR TITLE
increase resources for API service

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -347,17 +347,17 @@ api:
   # https://docs.gunicorn.org/en/stable/design.html#how-many-workers
   uvicornNumWorkers: "9"
   nodeSelector:
-    role-datasets-server: "true"
-  replicas: 8
+    role-datasets-server-api: "true"
+  replicas: 12
   service:
     type: NodePort
   resources:
     requests:
-      cpu: 1
-      memory: "8Gi"
+      cpu: 4
+      memory: "14Gi"
     limits:
       cpu: 4
-      memory: "8Gi"
+      memory: "14Gi"
 
 rows:
   # Number of uvicorn workers for running the application


### PR DESCRIPTION
Related to #2690

See https://github.com/huggingface/infra/pull/940 (internal) which provides more resources, in a specific new "role" (role-datasets-server-api)

It provides up to 6 m6a.4xlarge nodes, each of which has 16 vCPUs and 64GB RAM. So: each node should get 4 pods, we should use 3 nodes, and have room to scale up twice

---


blocked by https://github.com/huggingface/infra/pull/940