### PR TITLE
feat(chart): search api exposed directly with ALB

### DIFF
--- a/chart/nginx-templates/default.conf.template
+++ b/chart/nginx-templates/default.conf.template
@@ -64,6 +64,15 @@ server {
     proxy_http_version 1.1;
   }
 
+  location /search {
+    proxy_pass ${URL_SEARCH}/search;
+    proxy_set_header Host $proxy_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+  }
+
   location /filter {
     proxy_pass ${URL_SEARCH}/filter;
     proxy_set_header Host $proxy_host;

--- a/chart/nginx-templates/default.conf.template
+++ b/chart/nginx-templates/default.conf.template
@@ -64,15 +64,6 @@ server {
     proxy_http_version 1.1;
   }
 
-  location /search {
-    proxy_pass ${URL_SEARCH}/search;
-    proxy_set_header Host $proxy_host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_http_version 1.1;
-  }
-
   location /filter {
     proxy_pass ${URL_SEARCH}/filter;
     proxy_set_header Host $proxy_host;

--- a/chart/templates/services/search/ingress.yaml
+++ b/chart/templates/services/search/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.global.huggingface.ingress.enabled .Values.ingress.enabled .Values.search.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  {{- $annotations := fromYaml (include "datasetsServer.ingress.annotations" .) }}
+  annotations: {{ toYaml $annotations | nindent 4 }}
+  labels: {{ include "labels.search" . | nindent 4 }}
+  name: "{{ include "name" . }}-search"
+  namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+    - host: {{ include "datasetsServer.ingress.hostname" . }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: "{{ include "name" . }}-search"
+                port:
+                  name: http
+            path: /search
+            pathType: Prefix
+  {{- if include "hf.common.ingress.certManagerRequest" ( dict "annotations" $annotations ) }}
+  tls:
+    - hosts:
+        - {{ include "datasetsServer.ingress.hostname" . }}
+      secretName: {{ printf "%s-tls" (include "datasetsServer.ingress.hostname" .) }}
+  {{- else if .Values.ingress.tls -}}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -583,6 +583,8 @@ search:
   service:
     type: ""
     annotations: {}
+  ingress:
+    enabled: true
   tolerations: []
 
 sseApi:


### PR DESCRIPTION
As discussed in #468, let's start to remove nginx proxy.
In this PR, we begin with the search API.