### PR TITLE
Align clean downloads schedule

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -233,8 +233,6 @@ cleanDuckdbIndexCache:
   expiredTimeIntervalSeconds: 259_200 # 3 days
 
 cleanDuckdbIndexDownloads:
-  schedule: "*/10 * * * *"
-  # every 10 minutes
   nodeSelector:
     role-datasets-server: "true"
   expiredTimeIntervalSeconds: 259_200 # 3 days

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -360,8 +360,8 @@ cleanDuckdbIndexDownloads:
   log:
     level: "info"
   action: "clean-directory"
-  schedule: "0 0 * * *"
-  # at 00:00
+  schedule: "0 */3 * * *"
+  # every 3 hours
   nodeSelector: {}
   resources:
     requests:


### PR DESCRIPTION
Rollback of https://github.com/huggingface/dataset-viewer/pull/2716 and align schedule with cache folder