### PR TITLE
Set s3fs max_paths

### DIFF
--- a/libs/libcommon/src/libcommon/storage_client.py
+++ b/libs/libcommon/src/libcommon/storage_client.py
@@ -58,6 +58,7 @@ class StorageClient:
                 key=s3_config.access_key_id,
                 secret=s3_config.secret_access_key,
                 client_kwargs={"region_name": s3_config.region_name},
+                max_paths=100,  # to avoid the DirCache from growing too much
             )
         elif protocol == "file":
             self._fs = fsspec.filesystem(protocol, auto_mkdir=True)


### PR DESCRIPTION
Maybe can help to save some RAM in API workers (https://github.com/huggingface/dataset-viewer/issues/2395)

The S3FileSystem DirCache can grow indefinitely. It is used to store assets and cached assets (image/audio) for the viewer.