### PR TITLE
Set non-package mode

### DIFF
--- a/.github/workflows/_quality-python.yml
+++ b/.github/workflows/_quality-python.yml
@@ -40,15 +40,19 @@ jobs:
         run: |
           poetry env use "${{ env.python-version }}"
           poetry install
-      - name: Run ruff linter on src
-        run: poetry run ruff check src
-      - name: Run ruff linter on tests
-        run: poetry run ruff check tests --ignore=ARG
+      - name: Run ruff linter
+        run: |
+          if [ -d src ]; then poetry run ruff check src; fi
+          if [ -d tests ]; then poetry run ruff check tests --ignore=ARG; fi
       - name: Run ruff formatter
-        run: poetry run ruff format --check src tests
+        run: |
+          if [ -d src ]; then poetry run ruff format --check src; fi
+          if [ -d tests ]; then poetry run ruff format --check tests; fi
       - name: Run mypy
-        run: poetry run mypy tests src
+        run: |
+          if [ -d src ]; then poetry run mypy src; fi
+          if [ -d tests ]; then poetry run mypy tests; fi
       - name: Run bandit
-        run: poetry run bandit -r src
+        run: if [ -d src ]; then poetry run bandit -r src; fi
       - name: Run pip-audit
         run: bash -c "poetry run pip-audit --ignore-vuln GHSA-wj6h-64fc-37mp --ignore-vuln GHSA-wfm5-v35h-vwf4 --ignore-vuln GHSA-cwvm-v4w8-q58c --ignore-vuln PYSEC-2022-43059 -r <(poetry export -f requirements.txt --with dev | sed '/^libapi @/d' | sed '/^libcommon @/d')"

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.poetry]
+package-mode = false
 authors = ["Sylvain Lesage <sylvain.lesage@huggingface.co>"]
 description = "Documentation for dataset-viewer"
 name = "dataset-viewer-doc"

--- a/e2e/pyproject.toml
+++ b/e2e/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.poetry]
+package-mode = false
 authors = ["Sylvain Lesage <sylvain.lesage@huggingface.co>"]
 description = "End to end tests"
 name = "e2e"

--- a/e2e/src/__init__.py
+++ b/e2e/src/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 The HuggingFace Authors.

--- a/e2e/src/e2e/__init__.py
+++ b/e2e/src/e2e/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 The HuggingFace Authors.

--- a/front/admin_ui/pyproject.toml
+++ b/front/admin_ui/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.poetry]
+package-mode = false
 name = "admin-ui"
 version = "0.1.0"
 description = "Admin interface for the dataset viewer"

--- a/tools/Python.mk
+++ b/tools/Python.mk
@@ -16,18 +16,27 @@ lock:
 # Check that source code meets quality standards + security
 .PHONY: quality
 quality:
-	$(POETRY) run ruff check src
-	$(POETRY) run ruff check tests --ignore=ARG
-	$(POETRY) run ruff format --check src tests
-	$(POETRY) run mypy tests src
-	$(POETRY) run bandit -r src
+# Run ruff linter
+	if [ -d src ]; then $(POETRY) run ruff check src; fi
+	if [ -d tests ]; then $(POETRY) run ruff check tests --ignore=ARG; fi
+# Run ruff formatter
+	if [ -d src ]; then $(POETRY) run ruff format --check src; fi
+	if [ -d tests ]; then $(POETRY) run ruff format --check tests; fi
+# Run mypy
+	if [ -d src ]; then $(POETRY) run mypy src; fi
+	if [ -d tests ]; then $(POETRY) run mypy tests; fi
+# Run bandit
+	if [ -d src ]; then $(POETRY) run bandit -r src; fi
 
 # Format source code automatically
 .PHONY: style
 style:
-	$(POETRY) run ruff check --fix src
-	$(POETRY) run ruff check --fix tests --ignore=ARG
-	$(POETRY) run ruff format src tests
+# Run ruff linter
+	if [ -d src ]; then $(POETRY) run ruff check --fix src; fi
+	if [ -d tests ]; then $(POETRY) run ruff check --fix tests --ignore=ARG; fi
+# Run ruff formatter
+	if [ -d src ]; then $(POETRY) run ruff format src; fi
+	if [ -d tests ]; then $(POETRY) run ruff format tests; fi
 
 .PHONY: pip-audit
 pip-audit:


### PR DESCRIPTION
Once that we have updated Poetry to 1.8.2, we can set non-package mode in the components we are not packaging:
- docs
- admin-ui
- e2e

Note that currently a warning was raised when installing (poetry@1.8.2 install) the docs and the admin-ui components:
```
Warning: The current project could not be installed: No file/folder found for package dataset-viewer-doc
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
In a future version of Poetry this warning will become an error!
```