### PR TITLE
Change search resources

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -377,7 +377,7 @@ search:
   uvicornNumWorkers: "2"
   nodeSelector:
     role-datasets-server-search: "true"
-  replicas: 4
+  replicas: 3
   service:
     type: NodePort
   ingress:
@@ -390,10 +390,10 @@ search:
   resources:
     requests:
       cpu: 1
-      memory: "30Gi"
+      memory: "250Gi"
     limits:
-      cpu: 16
-      memory: "30Gi"
+      cpu: 64
+      memory: "250Gi"
 
 sseApi:
   # Number of uvicorn workers for running the application


### PR DESCRIPTION
The current instance type for the search service is [r6id.16xlarge](https://github.com/huggingface/infra/blob/1288ec190493ef0da24cbbc5422ea94ed84924ea/projects/hub/00-aws/variables/hub-aws-prod-us-east-1.tfvars#L192C24-L192C37)
![image](https://github.com/huggingface/dataset-viewer/assets/5564745/fff3b974-672d-40e6-a8d2-878d71c1d7b8)
I think we can adjust the new values for CPU and memory and also reduce the number of replicas (we still have a low number of requests)