### PR TITLE
Update DatasetWithScriptNotSupportedError message suggesting CLI

### DIFF
--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -532,7 +532,12 @@ class UnsupportedExternalFilesError(CacheableError):
 class DatasetWithScriptNotSupportedError(CacheableError):
     """We don't support some datasets because they have a dataset script."""
 
-    def __init__(self, message: str, cause: Optional[BaseException] = None):
+    def __init__(self, message: str = "", cause: Optional[BaseException] = None):
+        message = message or (
+            "The dataset viewer doesn't support this dataset because it runs arbitrary Python code. "
+            "You can convert it to a Parquet data-only dataset by using the convert_to_parquet CLI from the datasets "
+            "library. See: https://huggingface.co/docs/datasets/main/en/cli#convert-to-parquet"
+        )  # TODO: Change URL after next datasets release
         super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "DatasetWithScriptNotSupportedError", cause, True)
 
 

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -1241,11 +1241,7 @@ def compute_config_parquet_and_info_response(
         raise EmptyDatasetError(f"{dataset=} is empty.", cause=err) from err
     except ValueError as err:
         if "trust_remote_code" in str(err):
-            raise DatasetWithScriptNotSupportedError(
-                "The dataset viewer doesn't support this dataset because it runs "
-                "arbitrary python code. Please open a discussion in the discussion tab "
-                "if you think this is an error and tag @lhoestq and @severo."
-            ) from err
+            raise DatasetWithScriptNotSupportedError from err
         raise
     except FileNotFoundError as err:
         raise DatasetNotFoundError("The dataset, or the revision, does not exist on the Hub.") from err

--- a/services/worker/src/worker/job_runners/config/split_names.py
+++ b/services/worker/src/worker/job_runners/config/split_names.py
@@ -78,11 +78,7 @@ def compute_split_names_from_streaming_response(
         raise EmptyDatasetError("The dataset is empty.", cause=err) from err
     except Exception as err:
         if isinstance(err, ValueError) and "trust_remote_code" in str(err):
-            raise DatasetWithScriptNotSupportedError(
-                "The dataset viewer doesn't support this dataset because it runs "
-                "arbitrary python code. Please open a discussion in the discussion tab "
-                "if you think this is an error and tag @lhoestq and @severo."
-            ) from err
+            raise DatasetWithScriptNotSupportedError from err
         raise SplitNamesFromStreamingError(
             f"Cannot get the split names for the config '{config}' of the dataset.",
             cause=err,

--- a/services/worker/src/worker/job_runners/dataset/config_names.py
+++ b/services/worker/src/worker/job_runners/dataset/config_names.py
@@ -110,11 +110,7 @@ def compute_config_names_response(
         raise EmptyDatasetError("The dataset is empty.", cause=err) from err
     except ValueError as err:
         if "trust_remote_code" in str(err):
-            raise DatasetWithScriptNotSupportedError(
-                "The dataset viewer doesn't support this dataset because it runs "
-                "arbitrary python code. Please open a discussion in the discussion tab "
-                "if you think this is an error and tag @lhoestq and @severo."
-            ) from err
+            raise DatasetWithScriptNotSupportedError from err
         raise ConfigNamesError("Cannot get the config names for the dataset.", cause=err) from err
     except ImportError as err:
         # this should only happen if the dataset is in the allow list, which should soon disappear

--- a/services/worker/src/worker/job_runners/split/first_rows.py
+++ b/services/worker/src/worker/job_runners/split/first_rows.py
@@ -218,11 +218,7 @@ def compute_first_rows_from_streaming_response(
         )
     except Exception as err:
         if isinstance(err, ValueError) and "trust_remote_code" in str(err):
-            raise DatasetWithScriptNotSupportedError(
-                "The dataset viewer doesn't support this dataset because it runs "
-                "arbitrary python code. Please open a discussion in the discussion tab "
-                "if you think this is an error and tag @lhoestq and @severo."
-            ) from err
+            raise DatasetWithScriptNotSupportedError from err
         raise InfoError(
             f"The info cannot be fetched for the config '{config}' of the dataset.",
             cause=err,
@@ -246,11 +242,7 @@ def compute_first_rows_from_streaming_response(
             features = iterable_dataset.features
         except Exception as err:
             if isinstance(err, ValueError) and "trust_remote_code" in str(err):
-                raise DatasetWithScriptNotSupportedError(
-                    "The dataset viewer doesn't support this dataset because it runs "
-                    "arbitrary python code. Please open a discussion in the discussion tab "
-                    "if you think this is an error and tag @lhoestq and @severo."
-                ) from err
+                raise DatasetWithScriptNotSupportedError from err
             raise FeaturesError(
                 (
                     f"Cannot extract the features (columns) for the split '{split}' of the config '{config}' of the"

--- a/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
+++ b/services/worker/src/worker/job_runners/split/opt_in_out_urls_scan_from_streaming.py
@@ -180,11 +180,7 @@ def compute_opt_in_out_urls_scan_response(
         )
     except Exception as err:
         if isinstance(err, ValueError) and "trust_remote_code" in str(err):
-            raise DatasetWithScriptNotSupportedError(
-                "The dataset viewer doesn't support this dataset because it runs "
-                "arbitrary python code. Please open a discussion in the discussion tab "
-                "if you think this is an error and tag @lhoestq and @severo."
-            ) from err
+            raise DatasetWithScriptNotSupportedError from err
         raise InfoError(
             f"The info cannot be fetched for the config '{config}' of the dataset.",
             cause=err,

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -100,11 +100,7 @@ def get_rows_or_raise(
         )
     except Exception as err:
         if isinstance(err, ValueError) and "trust_remote_code" in str(err):
-            raise DatasetWithScriptNotSupportedError(
-                "The dataset viewer doesn't support this dataset because it runs "
-                "arbitrary python code. Please open a discussion in the discussion tab "
-                "if you think this is an error and tag @lhoestq and @severo."
-            ) from err
+            raise DatasetWithScriptNotSupportedError from err
         MAX_SIZE_FALLBACK = 100_000_000
         if max_size_fallback:
             warnings.warn(
@@ -130,11 +126,7 @@ def get_rows_or_raise(
             )
         except Exception as err:
             if isinstance(err, ValueError) and "trust_remote_code" in str(err):
-                raise DatasetWithScriptNotSupportedError(
-                    "The dataset viewer doesn't support this dataset because it runs "
-                    "arbitrary python code. Please open a discussion in the discussion tab "
-                    "if you think this is an error and tag @lhoestq and @severo."
-                ) from err
+                raise DatasetWithScriptNotSupportedError from err
             raise NormalRowsError(
                 "Cannot load the dataset split (in normal download mode) to extract the first rows.",
                 cause=err,


### PR DESCRIPTION
Suggest using the `datasets` convert_to_parquet CLI instead of opening a Discussion.

Additionally, this PR sets a default error message, instead of repeating the same everywhere.

Fix #2742.