### PR TITLE
Delete the cache entries before backfilling again if cache is incoherent (inexisting config or split names)

### DIFF
--- a/libs/libcommon/src/libcommon/operations.py
+++ b/libs/libcommon/src/libcommon/operations.py
@@ -23,7 +23,7 @@ from libcommon.exceptions import (
     NotSupportedRepositoryNotFoundError,
 )
 from libcommon.orchestrator import TasksStatistics, backfill, get_revision, remove_dataset, set_revision
-from libcommon.state import UnexceptedConfigNamesError
+from libcommon.state import IncoherentCacheError
 from libcommon.storage_client import StorageClient
 from libcommon.utils import raise_if_blocked
 
@@ -263,9 +263,9 @@ def backfill_dataset(
         return delete_dataset(dataset=dataset, storage_clients=storage_clients)
     try:
         tasks_statistics = backfill(dataset=dataset, revision=revision, priority=priority)
-    except UnexceptedConfigNamesError:
+    except IncoherentCacheError:
         logging.warning(
-            f"Dataset {dataset} has unexpected config names in cache. Let's first delete the dataset, then backfill again."
+            f"Dataset {dataset} has incoherent entries in the cache. Let's first delete the dataset, then backfill again."
         )
         delete_dataset(dataset=dataset, storage_clients=storage_clients)
         tasks_statistics = backfill(dataset=dataset, revision=revision, priority=priority)

--- a/libs/libcommon/tests/test_operations.py
+++ b/libs/libcommon/tests/test_operations.py
@@ -14,6 +14,7 @@ from huggingface_hub.hf_api import DatasetInfo, HfApi
 from huggingface_hub.utils import HfHubHTTPError
 from requests import Response  # type: ignore
 
+from libcommon.constants import DATASET_CONFIG_NAMES_KIND
 from libcommon.dtos import JobResult
 from libcommon.exceptions import (
     DatasetInBlockListError,
@@ -29,6 +30,7 @@ from libcommon.operations import (
     update_dataset,
 )
 from libcommon.orchestrator import finish_job
+from libcommon.processing_graph import specification
 from libcommon.queue import Queue
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import get_cache_entries_df, has_some_cache, upsert_response
@@ -367,3 +369,50 @@ def test_2274_only_one_entry(
 
         assert not queue.get_pending_jobs_df(dataset=dataset).empty
         assert len(get_cache_entries_df(dataset=dataset)) == 1
+
+
+@pytest.mark.parametrize(
+    "config_names,should_be_recreated",
+    [(["config_ok"], False), (["config_nok"], True), (["config_ok", "config_nok"], True)],
+)
+def test_2767_delete_inexistent_configs(
+    queue_mongo_resource: QueueMongoResource,
+    cache_mongo_resource: CacheMongoResource,
+    config_names: list[str],
+    should_be_recreated: bool,
+) -> None:
+    # see https://github.com/huggingface/dataset-viewer/issues/2767
+    with tmp_dataset(namespace=NORMAL_USER, token=NORMAL_USER_TOKEN, private=False) as dataset:
+        revision = get_latest_dataset_revision_if_supported_or_raise(
+            dataset=dataset,
+            hf_endpoint=CI_HUB_ENDPOINT,
+            hf_token=NORMAL_USER_TOKEN,
+        )
+        upsert_response(
+            kind=DATASET_CONFIG_NAMES_KIND,
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": "config_ok"}]},
+            http_status=HTTPStatus.OK,
+            job_runner_version=specification[DATASET_CONFIG_NAMES_KIND]["job_runner_version"],
+            dataset_git_revision=revision,
+        )
+        for config_name in config_names:
+            upsert_response(
+                kind="config-split-names",
+                dataset=dataset,
+                config=config_name,
+                content={"not": "important"},
+                http_status=HTTPStatus.OK,
+                job_runner_version=specification["config-split-names"]["job_runner_version"],
+                dataset_git_revision=revision,
+            )
+        operation_statistics = backfill_dataset(dataset=dataset, hf_endpoint=CI_HUB_ENDPOINT, hf_token=CI_APP_TOKEN)
+        assert operation_statistics.num_backfilled_datasets == 1
+        # ^ when the config names contain something else than "config_ok", the dataset should have been deleted in the cache,
+        # and the first job should have been created again
+        if should_be_recreated:
+            assert Queue().has_pending_jobs(dataset=dataset, job_types=[DATASET_CONFIG_NAMES_KIND])
+            assert get_cache_entries_df(dataset=dataset).empty
+        else:
+            assert not Queue().has_pending_jobs(dataset=dataset, job_types=[DATASET_CONFIG_NAMES_KIND])
+            assert len(get_cache_entries_df(dataset=dataset)) == len(config_names) + 1

--- a/libs/libcommon/tests/test_operations.py
+++ b/libs/libcommon/tests/test_operations.py
@@ -14,7 +14,7 @@ from huggingface_hub.hf_api import DatasetInfo, HfApi
 from huggingface_hub.utils import HfHubHTTPError
 from requests import Response  # type: ignore
 
-from libcommon.constants import DATASET_CONFIG_NAMES_KIND
+from libcommon.constants import CONFIG_SPLIT_NAMES_KIND, DATASET_CONFIG_NAMES_KIND
 from libcommon.dtos import JobResult
 from libcommon.exceptions import (
     DatasetInBlockListError,
@@ -398,12 +398,12 @@ def test_2767_delete_inexistent_configs(
         )
         for config_name in config_names:
             upsert_response(
-                kind="config-split-names",
+                kind=CONFIG_SPLIT_NAMES_KIND,
                 dataset=dataset,
                 config=config_name,
                 content={"not": "important"},
                 http_status=HTTPStatus.OK,
-                job_runner_version=specification["config-split-names"]["job_runner_version"],
+                job_runner_version=specification[CONFIG_SPLIT_NAMES_KIND]["job_runner_version"],
                 dataset_git_revision=revision,
             )
         operation_statistics = backfill_dataset(dataset=dataset, hf_endpoint=CI_HUB_ENDPOINT, hf_token=CI_APP_TOKEN)
@@ -416,3 +416,61 @@ def test_2767_delete_inexistent_configs(
         else:
             assert not Queue().has_pending_jobs(dataset=dataset, job_types=[DATASET_CONFIG_NAMES_KIND])
             assert len(get_cache_entries_df(dataset=dataset)) == len(config_names) + 1
+
+
+@pytest.mark.parametrize(
+    "split_names,should_be_recreated",
+    [(["split_ok"], False), (["split_nok"], True), (["split_ok", "split_nok"], True)],
+)
+def test_2767_delete_inexistent_splits(
+    queue_mongo_resource: QueueMongoResource,
+    cache_mongo_resource: CacheMongoResource,
+    split_names: list[str],
+    should_be_recreated: bool,
+) -> None:
+    # see https://github.com/huggingface/dataset-viewer/issues/2767
+    with tmp_dataset(namespace=NORMAL_USER, token=NORMAL_USER_TOKEN, private=False) as dataset:
+        config = "config"
+        revision = get_latest_dataset_revision_if_supported_or_raise(
+            dataset=dataset,
+            hf_endpoint=CI_HUB_ENDPOINT,
+            hf_token=NORMAL_USER_TOKEN,
+        )
+        upsert_response(
+            kind=DATASET_CONFIG_NAMES_KIND,
+            dataset=dataset,
+            content={"config_names": [{"dataset": dataset, "config": config}]},
+            http_status=HTTPStatus.OK,
+            job_runner_version=specification[DATASET_CONFIG_NAMES_KIND]["job_runner_version"],
+            dataset_git_revision=revision,
+        )
+        upsert_response(
+            kind=CONFIG_SPLIT_NAMES_KIND,
+            dataset=dataset,
+            config=config,
+            content={"splits": [{"dataset": dataset, "config": config, "split": "split_ok"}]},
+            http_status=HTTPStatus.OK,
+            job_runner_version=specification[CONFIG_SPLIT_NAMES_KIND]["job_runner_version"],
+            dataset_git_revision=revision,
+        )
+        for split_name in split_names:
+            upsert_response(
+                kind="split-first-rows",
+                dataset=dataset,
+                config=config,
+                split=split_name,
+                content={"not": "important"},
+                http_status=HTTPStatus.OK,
+                job_runner_version=specification["split-first-rows"]["job_runner_version"],
+                dataset_git_revision=revision,
+            )
+        operation_statistics = backfill_dataset(dataset=dataset, hf_endpoint=CI_HUB_ENDPOINT, hf_token=CI_APP_TOKEN)
+        assert operation_statistics.num_backfilled_datasets == 1
+        # ^ when the split names contain something else than "split_ok", the dataset should have been deleted in the cache,
+        # and the first job should have been created again
+        if should_be_recreated:
+            assert Queue().has_pending_jobs(dataset=dataset, job_types=[DATASET_CONFIG_NAMES_KIND])
+            assert get_cache_entries_df(dataset=dataset).empty
+        else:
+            assert not Queue().has_pending_jobs(dataset=dataset, job_types=[DATASET_CONFIG_NAMES_KIND])
+            assert len(get_cache_entries_df(dataset=dataset)) == len(split_names) + 2


### PR DESCRIPTION
fixes #2767.

Hopefully, applying this to production will delete a lot of obsolete cache entries after the next backfill