### PR TITLE
Set max number of splits

### DIFF
--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -87,6 +87,7 @@ CacheableErrorCode = Literal[
     "DatasetWithTooComplexDataFilesPatternsError",
     "DatasetWithTooManyConfigsError",
     "DatasetWithTooManyParquetFilesError",
+    "DatasetWithTooManySplitsError",
     "DiskError",
     "DuckDBIndexFileNotFoundError",
     "EmptyDatasetError",

--- a/libs/libcommon/src/libcommon/exceptions.py
+++ b/libs/libcommon/src/libcommon/exceptions.py
@@ -221,6 +221,13 @@ class DatasetWithTooManyConfigsError(CacheableError):
         super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "DatasetWithTooManyConfigsError", cause, True)
 
 
+class DatasetWithTooManySplitsError(CacheableError):
+    """The number of splits of a dataset exceeded the limit."""
+
+    def __init__(self, message: str, cause: Optional[BaseException] = None):
+        super().__init__(message, HTTPStatus.NOT_IMPLEMENTED, "DatasetWithTooManySplitsError", cause, True)
+
+
 class DatasetWithTooManyParquetFilesError(CacheableError):
     """The number of parquet files of a dataset is too big."""
 

--- a/services/worker/src/worker/config.py
+++ b/services/worker/src/worker/config.py
@@ -259,6 +259,22 @@ class ConfigNamesConfig:
             )
 
 
+SPLIT_NAMES_MAX_NUMBER = 30
+
+
+@dataclass(frozen=True)
+class SplitNamesConfig:
+    max_number: int = SPLIT_NAMES_MAX_NUMBER
+
+    @classmethod
+    def from_env(cls) -> "SplitNamesConfig":
+        env = Env(expand_vars=True)
+        with env.prefixed("SPLIT_NAMES_"):
+            return cls(
+                max_number=env.int(name="MAX_NUMBER", default=SPLIT_NAMES_MAX_NUMBER),
+            )
+
+
 DUCKDB_INDEX_CACHE_DIRECTORY = None
 DUCKDB_INDEX_COMMIT_MESSAGE = "Update duckdb index file"
 DUCKDB_INDEX_COMMITTER_HF_TOKEN = None
@@ -331,6 +347,7 @@ class AppConfig:
     queue: QueueConfig = field(default_factory=QueueConfig)
     rows_index: RowsIndexConfig = field(default_factory=RowsIndexConfig)
     s3: S3Config = field(default_factory=S3Config)
+    split_names: SplitNamesConfig = field(default_factory=SplitNamesConfig)
     worker: WorkerConfig = field(default_factory=WorkerConfig)
     urls_scan: OptInOutUrlsScanConfig = field(default_factory=OptInOutUrlsScanConfig)
     parquet_metadata: ParquetMetadataConfig = field(default_factory=ParquetMetadataConfig)
@@ -351,6 +368,7 @@ class AppConfig:
             parquet_and_info=ParquetAndInfoConfig.from_env(),
             queue=QueueConfig.from_env(),
             s3=S3Config.from_env(),
+            split_names=SplitNamesConfig.from_env(),
             worker=WorkerConfig.from_env(),
             urls_scan=OptInOutUrlsScanConfig.from_env(),
             parquet_metadata=ParquetMetadataConfig.from_env(),

--- a/services/worker/src/worker/job_runners/config/split_names.py
+++ b/services/worker/src/worker/job_runners/config/split_names.py
@@ -11,6 +11,7 @@ from libcommon.dtos import FullSplitItem
 from libcommon.exceptions import (
     DatasetManualDownloadError,
     DatasetWithScriptNotSupportedError,
+    DatasetWithTooManySplitsError,
     EmptyDatasetError,
     PreviousStepFormatError,
     SplitNamesFromStreamingError,
@@ -25,6 +26,7 @@ from worker.utils import resolve_trust_remote_code
 def compute_split_names_from_streaming_response(
     dataset: str,
     config: str,
+    max_number: int,
     dataset_scripts_allow_list: list[str],
     hf_token: Optional[str] = None,
 ) -> SplitsList:
@@ -47,6 +49,8 @@ def compute_split_names_from_streaming_response(
             The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.
         hf_token (`str`, *optional*):
             An authentication token (See https://huggingface.co/settings/token)
+        max_number (`str`):
+            Maximum number of splits.
 
     Raises:
         [~`libcommon.exceptions.DatasetManualDownloadError`]:
@@ -83,10 +87,17 @@ def compute_split_names_from_streaming_response(
             f"Cannot get the split names for the config '{config}' of the dataset.",
             cause=err,
         ) from err
+    if len(split_name_items) > max_number:
+        split_examples = ", ".join([split_name_item["split"] for split_name_item in split_name_items[:5]])
+        raise DatasetWithTooManySplitsError(
+            f"The {config} config contains {len(split_name_items)} while it should generally contain 3 splits maximum (train/validation/test). "
+            f"If the splits {split_examples}... are not used to differentiate between training and evaluation, please consider defining configs of this dataset instead. "
+            "You can find how to define configs instead of splits here: https://huggingface.co/docs/hub/datasets-data-files-configuration"
+        )
     return SplitsList(splits=split_name_items)
 
 
-def compute_split_names_from_info_response(dataset: str, config: str) -> SplitsList:
+def compute_split_names_from_info_response(dataset: str, config: str, max_number: int) -> SplitsList:
     """
     Get the response of 'config-split-names' for one specific dataset and config on huggingface.co
     computed from cached response in dataset-info step.
@@ -97,6 +108,8 @@ def compute_split_names_from_info_response(dataset: str, config: str) -> SplitsL
             by a `/`.
         config (`str`):
             A configuration name.
+        max_number (`str`):
+            Maximum number of splits.
 
     Raises:
         [~`libcommon.simple_cache.CachedArtifactError`]:
@@ -120,7 +133,13 @@ def compute_split_names_from_info_response(dataset: str, config: str) -> SplitsL
     split_name_items: list[FullSplitItem] = [
         {"dataset": dataset, "config": config, "split": str(split)} for split in splits_content
     ]
-
+    if len(split_name_items) > max_number:
+        split_examples = ", ".join([split_name_item["split"] for split_name_item in split_name_items[:5]])
+        raise DatasetWithTooManySplitsError(
+            f"The {config} config contains {len(split_name_items)} while it should generally contain 3 splits maximum (train/validation/test). "
+            f"If the splits {split_examples}... are not used to differentiate between training and evaluation, please consider defining configs of this dataset instead. "
+            "You can find how to define configs instead of splits here: https://huggingface.co/docs/hub/datasets-data-files-configuration"
+        )
     return SplitsList(splits=split_name_items)
 
 
@@ -131,7 +150,11 @@ class ConfigSplitNamesJobRunner(ConfigJobRunnerWithDatasetsCache):
 
     def compute(self) -> CompleteJobResult:
         try:
-            return CompleteJobResult(compute_split_names_from_info_response(dataset=self.dataset, config=self.config))
+            return CompleteJobResult(
+                compute_split_names_from_info_response(
+                    dataset=self.dataset, config=self.config, max_number=self.app_config.split_names.max_number
+                )
+            )
         except (CachedArtifactError, CachedArtifactNotFoundError):
             logging.info(
                 f"Cannot compute 'config-split-names' from config-info for {self.dataset=} {self.config=}. "
@@ -141,6 +164,7 @@ class ConfigSplitNamesJobRunner(ConfigJobRunnerWithDatasetsCache):
                 compute_split_names_from_streaming_response(
                     dataset=self.dataset,
                     config=self.config,
+                    max_number=self.app_config.split_names.max_number,
                     hf_token=self.app_config.common.hf_token,
                     dataset_scripts_allow_list=self.app_config.common.dataset_scripts_allow_list,
                 )

--- a/services/worker/tests/job_runners/config/test_split_names.py
+++ b/services/worker/tests/job_runners/config/test_split_names.py
@@ -163,7 +163,7 @@ def test_doesnotexist(
     dataset = "non_existent"
     config = "non_existent"
     with pytest.raises(CachedArtifactNotFoundError):
-        compute_split_names_from_info_response(dataset, config)
+        compute_split_names_from_info_response(dataset, config, max_number=999)
 
 
 @pytest.mark.parametrize(
@@ -237,6 +237,7 @@ def test_compute_split_names_from_streaming_response_raises(
         compute_split_names_from_streaming_response(
             hub_public_manual_download,
             "default",
+            max_number=999,
             hf_token=app_config.common.hf_token,
             dataset_scripts_allow_list=[hub_public_manual_download],
         )

--- a/services/worker/tests/job_runners/config/test_split_names.py
+++ b/services/worker/tests/job_runners/config/test_split_names.py
@@ -149,10 +149,10 @@ def test_compute_split_names_from_info_response(
 
     if error_code:
         with pytest.raises(Exception) as e:
-            compute_split_names_from_info_response(dataset, config)
+            compute_split_names_from_info_response(dataset, config, max_number=999)
         assert e.typename == error_code
     else:
-        assert compute_split_names_from_info_response(dataset, config) == content
+        assert compute_split_names_from_info_response(dataset, config, max_number=999) == content
 
 
 def test_doesnotexist(


### PR DESCRIPTION
To avoid cases with 300 splits = 300 load_dataset() * 300 data files resolutions = 90k calls to the Hub API to list files