### PR TITLE
Add missing comment

### DIFF
--- a/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
+++ b/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
@@ -504,7 +504,9 @@ def get_compatible_libraries_for_csv(dataset: str, hf_token: Optional[str], logi
         for loading_code in loading_codes:
             if len(loading_code["arguments"]["splits"]) == 1:
                 pattern = next(iter(loading_code["arguments"]["splits"].values()))
-                loading_code["code"] = DASK_CODE.format(function=function, dataset=dataset, pattern=pattern)
+                loading_code["code"] = DASK_CODE.format(
+                    function=function, dataset=dataset, pattern=pattern, comment=comment
+                )
             else:
                 loading_code["code"] = DASK_CODE_SPLITS.format(
                     function=function,


### PR DESCRIPTION
Part of https://github.com/huggingface/dataset-viewer/issues/1443
Currently we have 414 entries with UnexpectedErrorCode because of missing comment value:
`{kind:"dataset-compatible-libraries", http_status:{$ne:200}, "details.cause_exception":"KeyError", "details.copied_from_artifact":{$exists:false}}`

```
  File "/src/services/worker/src/worker/job_runners/dataset/compatible_libraries.py", line 507, in get_compatible_libraries_for_csv
    loading_code["code"] = DASK_CODE.format(function=function, dataset=dataset, pattern=pattern)
KeyError: 'comment'
```
