### PR TITLE
Give more ram to backfill cron jobs

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -174,21 +174,6 @@ mongodbMigration:
     limits:
       cpu: 1
 
-# --- jobs (post-install/upgrade hooks) ---
-
-deleteDuckdbIndexes:
-  nodeSelector:
-    role-datasets-server: "true"
-  tolerations:
-    - key: "huggingface.co/datasets-server"
-      operator: "Exists"
-      effect: "NoSchedule"
-  resources:
-    requests:
-      cpu: 1
-    limits:
-      cpu: 1
-
 # --- cron jobs  ---
 backfill:
   enabled: true

--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -191,10 +191,10 @@ backfill:
   resources:
     requests:
       cpu: 1
-      memory: "10Gi"
+      memory: "16Gi"
     limits:
       cpu: 2
-      memory: "10Gi"
+      memory: "16Gi"
 
 backfillRetryableErrors:
   enabled: true
@@ -212,7 +212,7 @@ backfillRetryableErrors:
   resources:
     requests:
       cpu: 1
-      memory: "1Gi"
+      memory: "8Gi"
     limits:
       cpu: 2
       memory: "8Gi"

--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -148,17 +148,6 @@ mongodbMigration:
     limits:
       cpu: 1
 
-# --- jobs (post-install/upgrade hooks) ---
-
-deleteDuckdbIndexes:
-  log:
-    level: "debug"
-  resources:
-    requests:
-      cpu: 100m
-    limits:
-      cpu: 1
-
 # --- cron jobs  ---
 backfill:
   enabled: false


### PR DESCRIPTION
The backfill jobs can restart 2, 3, even 6 times... due to OOM. And we end up with successive cron jobs occurring at the same time.