### PR TITLE
increase duckdb job runner version (follows #2737)

### DIFF
--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -667,7 +667,7 @@ specification: ProcessingGraphSpecification = {
     "split-duckdb-index": {
         "input_type": "split",
         "triggered_by": "config-parquet-metadata",
-        "job_runner_version": 2,
+        "job_runner_version": 3,
         "difficulty": 70,
         "bonus_difficulty_if_dataset_is_big": 20,
     },


### PR DESCRIPTION
fixes https://github.com/huggingface/dataset-viewer/pull/2737#issuecomment-2133157229

> shouldn't i update the job runner's version?

I don't increment the `split-descriptive-statistics` version, because I understand that the responses will not be changed, right?