### PR TITLE
block huggingface-leaderboard/*

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -79,7 +79,7 @@ images:
 
 common:
   # Comma-separated list of blocked datasets. No jobs will be processed for those datasets.
-  blockedDatasets: "open-llm-leaderboard/*,lunaluan/*,atom-in-the-universe/*,cot-leaderboard/cot-eval-traces,mitermix/yt-links,mcding-org/*"
+  blockedDatasets: "huggingface-leaderboard/*,open-llm-leaderboard/*,lunaluan/*,atom-in-the-universe/*,cot-leaderboard/cot-eval-traces,mitermix/yt-links,mcding-org/*"
   # Comma-separated list of the datasets for which we support dataset scripts.
   # Unix shell-style wildcards also work in the dataset name for namespaced datasets, for example `some_namespace/*` to refer to all the datasets in the `some_namespace` namespace.
   # The keyword `{{ALL_DATASETS_WITH_NO_NAMESPACE}}` refers to all the datasets without namespace.


### PR DESCRIPTION
Datasets like https://huggingface.co/datasets/huggingface-leaderboard/details_huggingface__llama-13b are redirected to https://huggingface.co/datasets/open-llm-leaderboard/details_huggingface__llama-13b, and the org https://huggingface.co/datasets/huggingface-leaderboard does not seem to exist, but we currently have 200k jobs for namespace "huggingface-leaderboard", so I'm blocking them.