### PR TITLE
 Run the backfill on retryable errors every 2 hours (not every 30 min)

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -205,7 +205,7 @@ backfillRetryableErrors:
   log:
     level: "debug"
   action: "backfill-retryable-errors"
-  schedule: "*/30 * * * *"
+  schedule: "0 */2 * * *"
   # every 30 minutes
   nodeSelector:
     role-datasets-server: "true"


### PR DESCRIPTION
We currently have four consecutive backfill-retryable-errors jobs running simultaneously, which could cause an overload of the DB.
I would like to see if it helps somehow other services. 