### PR TITLE
No mongo cache in DatasetRemovalPlan

### DIFF
--- a/libs/libcommon/src/libcommon/simple_cache.py
+++ b/libs/libcommon/src/libcommon/simple_cache.py
@@ -349,7 +349,7 @@ def delete_dataset_responses(dataset: str) -> int:
         `int`: The number of deleted documents.
     """
     existing_cache = CachedResponseDocument.objects(dataset=dataset)
-    for cache in existing_cache:
+    for cache in existing_cache.no_cache():
         decrease_metric(kind=cache.kind, http_status=cache.http_status, error_code=cache.error_code)
     num_deleted_cache_responses = existing_cache.delete()
     return 0 if num_deleted_cache_responses is None else num_deleted_cache_responses


### PR DESCRIPTION
don't keep the full query result in memory (as mongoengine does by default)

this should reduce the frequency of memory spikes and could have an effect of the memory issues we're having