### PR TITLE
Make StorageClient not warn when deleting a non-existing directory

### DIFF
--- a/libs/libcommon/src/libcommon/storage_client.py
+++ b/libs/libcommon/src/libcommon/storage_client.py
@@ -105,12 +105,15 @@ class StorageClient:
             int: The number of directories deleted (0 or 1)
         """
         dataset_key = self.get_full_path(dataset)
-        try:
-            self._fs.rm(dataset_key, recursive=True)
-            logging.info(f"Directory deleted: {dataset_key}")
-            return 1
-        except Exception:
-            logging.warning(f"Could not delete directory {dataset_key}")
+        if self._fs.exists(dataset_key):
+            try:
+                self._fs.rm(dataset_key, recursive=True)
+                logging.info(f"Directory deleted: {dataset_key}")
+                return 1
+            except Exception:
+                logging.warning(f"Could not delete directory {dataset_key}")
+                return 0
+        else:
             return 0
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Make StorageClient not warn when trying to delete a non-existing directory.

I think we should only log a warning if the directory exists and could not be deleted.
