### PR TITLE
Fix string representation of storage client

### DIFF
--- a/libs/libcommon/src/libcommon/storage_client.py
+++ b/libs/libcommon/src/libcommon/storage_client.py
@@ -114,4 +114,4 @@ class StorageClient:
             return 0
 
     def __repr__(self) -> str:
-        return f"StorageClient(protocol={self.protocol}, storage_root={self.storage_root}, base_url={self.base_url}, overwrite={self.overwrite}), url_signer={self.url_signer})"
+        return f"StorageClient(protocol={self.protocol}, storage_root={self.storage_root}, base_url={self.base_url}, overwrite={self.overwrite}, url_signer={self.url_signer})"

--- a/libs/libcommon/src/libcommon/storage_client.py
+++ b/libs/libcommon/src/libcommon/storage_client.py
@@ -113,5 +113,5 @@ class StorageClient:
             logging.warning(f"Could not delete directory {dataset_key}")
             return 0
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return f"StorageClient(protocol={self.protocol}, storage_root={self.storage_root}, base_url={self.base_url}, overwrite={self.overwrite}, url_signer={self.url_signer})"

--- a/libs/libcommon/src/libcommon/url_signer.py
+++ b/libs/libcommon/src/libcommon/url_signer.py
@@ -79,6 +79,9 @@ class URLSigner(ABC):
     def sign_url(self, url: str) -> str:
         pass
 
+    def __str__(self) -> str:
+        return self.__class__.__name__
+
     def _sign_asset_url_path_in_place(self, cell: Any, asset_url_path: AssetUrlPath) -> Any:
         if not cell:
             return cell


### PR DESCRIPTION
Fix string representation of storage client.

The string representation of the storage client is used by the orchestrator `DeleteDatasetStorageTask` in both the task `id` attribute and as a `label` for prometheus_client Histogram:
- https://github.com/huggingface/dataset-viewer/blob/1ea458cb22396f8af955bf5b1ebbb92d89f0a707/libs/libcommon/src/libcommon/orchestrator.py#L221
- https://github.com/huggingface/dataset-viewer/blob/1ea458cb22396f8af955bf5b1ebbb92d89f0a707/libs/libcommon/src/libcommon/orchestrator.py#L234

Since the inclusion of the URL signer to the storage client by PR:
- #2298

the string representation of the storage client is something like:
```
StorageClient(protocol=s3, storage_root=hf-datasets-server-statics-test/assets, base_url=https://datasets-server-test.us.dev.moon.huggingface.tech/assets, overwrite=True), url_signer=<libcommon.cloudfront.CloudFront object at 0x55f27a209110>)
```
- See the url_signer: `url_signer=<libcommon.cloudfront.CloudFront object at 0x55f27a209110>`
  - This is a different value for each `CloudFront` instantiation

This PR fixes the string representation of the URLSigner to be its class name, and therefore it fixes as well the string representation of the storage client to be something like:
```
StorageClient(protocol=s3, storage_root=hf-datasets-server-statics-test/assets, base_url=https://datasets-server-test.us.dev.moon.huggingface.tech/assets, overwrite=True), url_signer=CloudFront)
```
- See the url_signer is now: `url_signer=CloudFront`
