### PR TITLE
Use `HfFileSystem` in config-parquet-metadata step instead of `HttpFileSystem`

### DIFF
--- a/libs/libapi/src/libapi/duckdb.py
+++ b/libs/libapi/src/libapi/duckdb.py
@@ -12,7 +12,7 @@ from typing import Optional
 import anyio
 from anyio import Path
 from libcommon.constants import SPLIT_DUCKDB_INDEX_KIND
-from libcommon.parquet_utils import extract_split_name_from_parquet_url
+from libcommon.parquet_utils import extract_split_directory_from_parquet_url
 from libcommon.prometheus import StepProfiler
 from libcommon.simple_cache import CacheEntry
 from libcommon.storage import StrPath, init_dir
@@ -44,7 +44,7 @@ async def get_index_file_location_and_download_if_missing(
         # For directories like "partial-train" for the file
         # at "en/partial-train/0000.parquet" in the C4 dataset.
         # Note that "-" is forbidden for split names, so it doesn't create directory names collisions.
-        split_directory = extract_split_name_from_parquet_url(url)
+        split_directory = extract_split_directory_from_parquet_url(url)
         repo_file_location = f"{config}/{split_directory}/{filename}"
         index_file_location = f"{index_folder}/{repo_file_location}"
         index_path = Path(index_file_location)

--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -85,11 +85,11 @@ def parquet_export_is_partial(parquet_file_url: str) -> bool:
         `bool`: True is the Parquet export is partial,
             or False if it's the full dataset.
     """
-    split_directory_name_for_parquet_export = extract_split_name_from_parquet_url(parquet_file_url)
+    split_directory_name_for_parquet_export = extract_split_directory_from_parquet_url(parquet_file_url)
     return split_directory_name_for_parquet_export.startswith(PARTIAL_PREFIX)
 
 
-def extract_split_name_from_parquet_url(parquet_url: str) -> str:
+def extract_split_directory_from_parquet_url(parquet_url: str) -> str:
     """
     Extracts the split name from a parquet file URL
     stored in the `refs/convert/parquet` branch of a

--- a/libs/libcommon/src/libcommon/storage_client.py
+++ b/libs/libcommon/src/libcommon/storage_client.py
@@ -109,6 +109,8 @@ class StorageClient:
             self._fs.rm(dataset_key, recursive=True)
             logging.info(f"Directory deleted: {dataset_key}")
             return 1
+        except FileNotFoundError:
+            return 0
         except Exception:
             logging.warning(f"Could not delete directory {dataset_key}")
             return 0

--- a/libs/libcommon/tests/test_parquet_utils.py
+++ b/libs/libcommon/tests/test_parquet_utils.py
@@ -22,7 +22,7 @@ from libcommon.parquet_utils import (
     RowsIndex,
     SchemaMismatchError,
     TooBigRows,
-    extract_split_name_from_parquet_url,
+    extract_split_directory_from_parquet_url,
     get_num_parquet_files_to_process,
     parquet_export_is_partial,
 )
@@ -504,8 +504,8 @@ def test_indexer_schema_mistmatch_error(
         ),
     ],
 )
-def test_extract_split_name_from_parquet_url(parquet_url: str, expected: str) -> None:
-    split_name = extract_split_name_from_parquet_url(parquet_url)
+def test_extract_split_directory_from_parquet_url(parquet_url: str, expected: str) -> None:
+    split_name = extract_split_directory_from_parquet_url(parquet_url)
 
     assert split_name == expected
 

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -82,8 +82,8 @@ from worker.job_runners.config.config_job_runner import ConfigJobRunnerWithDatas
 from worker.utils import (
     LOCK_GIT_BRANCH_RETRY_SLEEPS,
     create_branch,
+    hf_hub_open_file,
     hf_hub_url,
-    open_file,
     raise_if_long_column_name,
     resolve_trust_remote_code,
 )
@@ -587,7 +587,7 @@ def retry_validate_get_num_examples_and_size(
         `tuple[int, int]` - (num examples, size in bytes)
     """
     try:
-        f = retry(on=[pa.ArrowInvalid], sleeps=SLEEPS)(open_file)(url, hf_endpoint, hf_token)
+        f = retry(on=[pa.ArrowInvalid], sleeps=SLEEPS)(hf_hub_open_file)(url, hf_endpoint, hf_token)
         pf, size = pq.ParquetFile(f), f.size
         if validate:
             validate(pf)
@@ -612,7 +612,7 @@ def retry_validate_get_features_num_examples_size_and_compression_ratio(
         `tuple[pq.ParquetFile, int]` - (parquet files, size in bytes)
     """
     try:
-        f = retry(on=[pa.ArrowInvalid], sleeps=SLEEPS)(open_file)(url, hf_endpoint, hf_token)
+        f = retry(on=[pa.ArrowInvalid], sleeps=SLEEPS)(hf_hub_open_file)(url, hf_endpoint, hf_token)
         pf, size = pq.ParquetFile(f), f.size
         num_row_groups = pf.metadata.num_row_groups
         compression_ratio = 0

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -82,17 +82,16 @@ from worker.job_runners.config.config_job_runner import ConfigJobRunnerWithDatas
 from worker.utils import (
     LOCK_GIT_BRANCH_RETRY_SLEEPS,
     create_branch,
-    hf_hub_open_file,
     hf_hub_url,
     raise_if_long_column_name,
     resolve_trust_remote_code,
+    retry_on_arrow_invalid_open_file,
 )
 
 DATASET_TYPE = "dataset"
 MAX_FILES_PER_DIRECTORY = 10_000  # hf hub limitation
 MAX_FILES_PER_REPOSITORY = 100_000  # hf hub limitation
 MAX_OPERATIONS_PER_COMMIT = 500
-SLEEPS = [0.2, 1, 1, 10, 10, 10]
 
 T = TypeVar("T")
 
@@ -587,7 +586,7 @@ def retry_validate_get_num_examples_and_size(
         `tuple[int, int]` - (num examples, size in bytes)
     """
     try:
-        f = retry(on=[pa.ArrowInvalid], sleeps=SLEEPS)(hf_hub_open_file)(url, hf_endpoint, hf_token)
+        f = retry_on_arrow_invalid_open_file(url, hf_endpoint, hf_token)
         pf, size = pq.ParquetFile(f), f.size
         if validate:
             validate(pf)
@@ -612,7 +611,7 @@ def retry_validate_get_features_num_examples_size_and_compression_ratio(
         `tuple[pq.ParquetFile, int]` - (parquet files, size in bytes)
     """
     try:
-        f = retry(on=[pa.ArrowInvalid], sleeps=SLEEPS)(hf_hub_open_file)(url, hf_endpoint, hf_token)
+        f = retry_on_arrow_invalid_open_file(url, hf_endpoint, hf_token)
         pf, size = pq.ParquetFile(f), f.size
         num_row_groups = pf.metadata.num_row_groups
         compression_ratio = 0

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -43,7 +43,6 @@ from huggingface_hub._commit_api import (
     CommitOperationDelete,
 )
 from huggingface_hub.hf_api import CommitInfo, DatasetInfo, HfApi, RepoFile
-from huggingface_hub.hf_file_system import HfFileSystem, HfFileSystemFile
 from huggingface_hub.utils._errors import HfHubHTTPError, RepositoryNotFoundError
 from huggingface_hub.utils._http import HTTP_METHOD_T, Response, http_backoff
 from libcommon.constants import (
@@ -84,6 +83,7 @@ from worker.utils import (
     LOCK_GIT_BRANCH_RETRY_SLEEPS,
     create_branch,
     hf_hub_url,
+    open_file,
     raise_if_long_column_name,
     resolve_trust_remote_code,
 )
@@ -574,11 +574,6 @@ class TooBigRowGroupsError(ParquetValidationError):
         super().__init__(*args)
         self.num_rows = num_rows
         self.row_group_byte_size = row_group_byte_size
-
-
-def open_file(file_url: str, hf_endpoint: str, hf_token: Optional[str]) -> HfFileSystemFile:
-    fs = HfFileSystem(endpoint=hf_endpoint, token=hf_token)
-    return fs.open(file_url)
 
 
 def retry_validate_get_num_examples_and_size(

--- a/services/worker/src/worker/job_runners/config/parquet_metadata.py
+++ b/services/worker/src/worker/job_runners/config/parquet_metadata.py
@@ -28,7 +28,7 @@ from worker.dtos import (
     ParquetFileMetadataItem,
 )
 from worker.job_runners.config.config_job_runner import ConfigJobRunner
-from worker.utils import hf_hub_open_file, hf_hub_parquet_path
+from worker.utils import hf_hub_open_file, hffs_parquet_url
 
 SLEEPS = [0.2, 1, 1, 10, 10, 10]
 
@@ -45,7 +45,7 @@ def create_parquet_metadata_file_from_remote_parquet(
     parquet_file_item: SplitHubFile, hf_endpoint: str, hf_token: Optional[str], parquet_metadata_directory: StrPath
 ) -> ParquetFileMetadataItem:
     split_directory = extract_split_name_from_parquet_url(parquet_file_item["url"])
-    hfh_parquet_file_path = hf_hub_parquet_path(
+    hfh_parquet_file_path = hffs_parquet_url(
         repo_id=parquet_file_item["dataset"],
         config=parquet_file_item["config"],
         split_directory=split_directory,

--- a/services/worker/src/worker/job_runners/config/parquet_metadata.py
+++ b/services/worker/src/worker/job_runners/config/parquet_metadata.py
@@ -13,7 +13,7 @@ from libcommon.exceptions import (
     ParquetResponseEmptyError,
     PreviousStepFormatError,
 )
-from libcommon.parquet_utils import extract_split_name_from_parquet_url
+from libcommon.parquet_utils import extract_split_directory_from_parquet_url
 from libcommon.simple_cache import get_previous_step_or_raise
 from libcommon.storage import StrPath
 from libcommon.utils import retry
@@ -44,7 +44,7 @@ def retry_open_file(
 def create_parquet_metadata_file_from_remote_parquet(
     parquet_file_item: SplitHubFile, hf_endpoint: str, hf_token: Optional[str], parquet_metadata_directory: StrPath
 ) -> ParquetFileMetadataItem:
-    split_directory = extract_split_name_from_parquet_url(parquet_file_item["url"])
+    split_directory = extract_split_directory_from_parquet_url(parquet_file_item["url"])
     hfh_parquet_file_path = hffs_parquet_url(
         repo_id=parquet_file_item["dataset"],
         config=parquet_file_item["config"],

--- a/services/worker/src/worker/job_runners/config/parquet_metadata.py
+++ b/services/worker/src/worker/job_runners/config/parquet_metadata.py
@@ -45,7 +45,7 @@ def create_parquet_metadata_file_from_remote_parquet(
     parquet_file_item: SplitHubFile, hf_endpoint: str, hf_token: Optional[str], parquet_metadata_directory: StrPath
 ) -> ParquetFileMetadataItem:
     split_directory = extract_split_name_from_parquet_url(parquet_file_item["url"])
-    hfh_file_url = f"datasets/{parquet_file_item['config']}/{split_directory}/{parquet_file_item['filename']}"
+    hfh_file_url = f"datasets/{parquet_file_item['dataset']}/{parquet_file_item['config']}/{split_directory}/{parquet_file_item['filename']}"
     try:
         # TODO: make revision config's parameter
         f = retry_open_file(

--- a/services/worker/src/worker/job_runners/config/parquet_metadata.py
+++ b/services/worker/src/worker/job_runners/config/parquet_metadata.py
@@ -6,6 +6,7 @@ import logging
 from typing import Optional
 
 from huggingface_hub import HfFileSystemFile
+from libcommon.constants import PARQUET_REVISION
 from libcommon.dtos import JobInfo, SplitHubFile
 from libcommon.exceptions import (
     FileSystemError,
@@ -51,9 +52,8 @@ def create_parquet_metadata_file_from_remote_parquet(
         filename=parquet_file_item["filename"],
     )
     try:
-        # TODO: make revision config's parameter
         f = retry_open_file(
-            file_url=hfh_parquet_file_path, hf_endpoint=hf_endpoint, hf_token=hf_token, revision="refs/convert/parquet"
+            file_url=hfh_parquet_file_path, hf_endpoint=hf_endpoint, hf_token=hf_token, revision=PARQUET_REVISION
         )
         parquet_file_metadata = ParquetFile(f).metadata
     except Exception as e:

--- a/services/worker/src/worker/job_runners/split/descriptive_statistics.py
+++ b/services/worker/src/worker/job_runners/split/descriptive_statistics.py
@@ -19,7 +19,7 @@ from libcommon.exceptions import (
     PreviousStepFormatError,
 )
 from libcommon.parquet_utils import (
-    extract_split_name_from_parquet_url,
+    extract_split_directory_from_parquet_url,
     get_num_parquet_files_to_process,
     is_list_pa_type,
     parquet_export_is_partial,
@@ -176,7 +176,7 @@ def compute_descriptive_statistics_response(
     logging.info(f"Downloading remote parquet files to a local directory {local_parquet_directory}. ")
     # For directories like "partial-train" for the file at "en/partial-train/0000.parquet" in the C4 dataset.
     # Note that "-" is forbidden for split names so it doesn't create directory names collisions.
-    split_directory = extract_split_name_from_parquet_url(split_parquet_files[0]["url"])
+    split_directory = extract_split_directory_from_parquet_url(split_parquet_files[0]["url"])
     for parquet_file in split_parquet_files:
         download_file_from_hub(
             repo_type=REPO_TYPE,

--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -29,7 +29,7 @@ from libcommon.exceptions import (
     PreviousStepFormatError,
 )
 from libcommon.parquet_utils import (
-    extract_split_name_from_parquet_url,
+    extract_split_directory_from_parquet_url,
     get_num_parquet_files_to_process,
     is_list_pa_type,
     parquet_export_is_partial,
@@ -227,7 +227,7 @@ def compute_split_duckdb_index_response(
 
         # For directories like "partial-train" for the file at "en/partial-train/0000.parquet" in the C4 dataset.
         # Note that "-" is forbidden for split names so it doesn't create directory names collisions.
-        split_directory = extract_split_name_from_parquet_url(split_parquet_files[0]["url"])
+        split_directory = extract_split_directory_from_parquet_url(split_parquet_files[0]["url"])
         partial_parquet_export = parquet_export_is_partial(split_parquet_files[0]["url"])
 
         num_parquet_files_to_index, num_bytes, num_rows = get_num_parquet_files_to_process(

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -140,7 +140,7 @@ def hf_hub_url(repo_id: str, filename: str, hf_endpoint: str, revision: str, url
 
 def hf_hub_parquet_path(repo_id: str, config: str, split_directory: str, filename: str) -> str:
     """Construct path of a dataset parquet file on the Hub, to be used with HfFileSystem."""
-    return f"datasets/{repo_id}/{config}/{split_directory}/{filename}"
+    return f"/datasets/{repo_id}/{config}/{split_directory}/{filename}"
 
 
 def hf_hub_open_file(

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -138,9 +138,15 @@ def hf_hub_url(repo_id: str, filename: str, hf_endpoint: str, revision: str, url
     return (hf_endpoint + url_template) % (repo_id, quote(revision, safe=""), filename)
 
 
-def open_file(
+def hf_hub_parquet_path(repo_id: str, config: str, split_directory: str, filename: str) -> str:
+    """Construct path of a dataset parquet file on the Hub, to be used with HfFileSystem."""
+    return f"datasets/{repo_id}/{config}/{split_directory}/{filename}"
+
+
+def hf_hub_open_file(
     file_url: str, hf_endpoint: str, hf_token: Optional[str], revision: Optional[str] = None
 ) -> HfFileSystemFile:
+    """Open file with the HfFileSystem."""
     fs = HfFileSystem(endpoint=hf_endpoint, token=hf_token)
     return fs.open(file_url, revision=revision)
 

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -139,7 +139,7 @@ def hf_hub_url(repo_id: str, filename: str, hf_endpoint: str, revision: str, url
 
 
 def hffs_parquet_url(repo_id: str, config: str, split_directory: str, filename: str) -> str:
-    """Construct path of a dataset parquet file on the Hub, to be used with HfFileSystem."""
+    """Construct url of a parquet file on the Hub, to be used with HfFileSystem."""
     return f"hf://datasets/{repo_id}/{config}/{split_directory}/{filename}"
 
 

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -138,9 +138,9 @@ def hf_hub_url(repo_id: str, filename: str, hf_endpoint: str, revision: str, url
     return (hf_endpoint + url_template) % (repo_id, quote(revision, safe=""), filename)
 
 
-def hf_hub_parquet_path(repo_id: str, config: str, split_directory: str, filename: str) -> str:
+def hffs_parquet_url(repo_id: str, config: str, split_directory: str, filename: str) -> str:
     """Construct path of a dataset parquet file on the Hub, to be used with HfFileSystem."""
-    return f"/datasets/{repo_id}/{config}/{split_directory}/{filename}"
+    return f"hf://datasets/{repo_id}/{config}/{split_directory}/{filename}"
 
 
 def hf_hub_open_file(

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -152,7 +152,7 @@ def hf_hub_open_file(
     return fs.open(file_url, revision=revision)
 
 
-# used by `config-parquet-and-info` and `parquet-metadata` steps
+# used by `config-parquet-and-info` and `config-parquet-metadata` steps
 @retry(on=[ArrowInvalid], sleeps=[0.2, 1, 1, 10, 10, 10])
 def retry_on_arrow_invalid_open_file(
     file_url: str, hf_endpoint: str, hf_token: Optional[str], revision: Optional[str] = None

--- a/services/worker/tests/job_runners/config/test_parquet_metadata.py
+++ b/services/worker/tests/job_runners/config/test_parquet_metadata.py
@@ -304,7 +304,7 @@ def test_compute(
         assert e.type.__name__ == expected_error_code
     else:
         with patch("worker.utils.hf_hub_open_file") as mock_OpenFile:
-            # create a new buffer within each test run time since the file is closed under the hood in .compute()
+            # create a new buffer within each test run since the file is closed under the hood in .compute()
             mock_OpenFile.return_value = get_dummy_parquet_buffer()
             content = job_runner.compute().content
             assert content == expected_content

--- a/services/worker/tests/job_runners/config/test_parquet_metadata.py
+++ b/services/worker/tests/job_runners/config/test_parquet_metadata.py
@@ -303,7 +303,7 @@ def test_compute(
             job_runner.compute()
         assert e.type.__name__ == expected_error_code
     else:
-        with patch("worker.job_runners.config.parquet_metadata.retry_open_file") as mock_OpenFile:
+        with patch("worker.utils.hf_hub_open_file") as mock_OpenFile:
             # create a new buffer within each test run time since the file is closed under the hood in .compute()
             mock_OpenFile.return_value = get_dummy_parquet_buffer()
             content = job_runner.compute().content

--- a/services/worker/tests/job_runners/config/test_parquet_metadata.py
+++ b/services/worker/tests/job_runners/config/test_parquet_metadata.py
@@ -17,7 +17,7 @@ from huggingface_hub import hf_hub_url
 from libcommon.constants import PARQUET_REVISION
 from libcommon.dtos import Priority, SplitHubFile
 from libcommon.exceptions import PreviousStepFormatError
-from libcommon.parquet_utils import ParquetIndexWithMetadata, extract_split_name_from_parquet_url
+from libcommon.parquet_utils import ParquetIndexWithMetadata, extract_split_directory_from_parquet_url
 from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import CachedArtifactError, upsert_response
 from libcommon.storage import StrPath
@@ -310,7 +310,7 @@ def test_compute(
             assert content == expected_content
             assert mock_OpenFile.call_count == len(upstream_content["parquet_files"])
             for parquet_file_item in upstream_content["parquet_files"]:
-                split_directory = extract_split_name_from_parquet_url(parquet_file_item["url"])
+                split_directory = extract_split_directory_from_parquet_url(parquet_file_item["url"])
                 path = hffs_parquet_url(dataset, config, split_directory, parquet_file_item["filename"])
                 mock_OpenFile.assert_any_call(
                     file_url=path,


### PR DESCRIPTION
`config-parquet-metadata` step is failing again for [FineWeb](https://huggingface.co/datasets/HuggingFaceFW/fineweb) with errors like 
```
"Could not read the parquet files: 504, message='Gateway Time-out', url=URL('https://huggingface.co/datasets/HuggingFaceFW/fineweb/resolve/refs%2Fconvert%2Fparquet/default/train-part1/4089.parquet')"
```
Maybe this would help (the same is used in `config-parquet-and-info` step which works).

Previous fix was https://github.com/huggingface/dataset-viewer/pull/2884