### PR TITLE
Pass copies of DataFrames instead of views

### DIFF
--- a/libs/libcommon/src/libcommon/orchestrator.py
+++ b/libs/libcommon/src/libcommon/orchestrator.py
@@ -525,16 +525,16 @@ class DatasetBackfillPlan(Plan):
                         dataset=self.dataset,
                         processing_graph=self.processing_graph,
                         revision=self.revision,
-                        pending_jobs_df=self.pending_jobs_df,
-                        cache_entries_df=self.cache_entries_df,
+                        pending_jobs_df=self.pending_jobs_df.copy(),
+                        cache_entries_df=self.cache_entries_df.copy(),
                     )
                     if self.only_first_processing_steps
                     else DatasetState(
                         dataset=self.dataset,
                         processing_graph=self.processing_graph,
                         revision=self.revision,
-                        pending_jobs_df=self.pending_jobs_df,
-                        cache_entries_df=self.cache_entries_df,
+                        pending_jobs_df=self.pending_jobs_df.copy(),
+                        cache_entries_df=self.cache_entries_df.copy(),
                     )
                 )
             with StepProfiler(


### PR DESCRIPTION
As the memory leak may be caused by improperly de-referenced objects, better pass copies of DataFrames instead of views.

In a subsequent PR I could try to optimize memory usage by not storing unnecessary data.