### PR TITLE
Fix skipped async tests caused by pytest-memray

### DIFF
--- a/.github/workflows/_e2e_tests.yml
+++ b/.github/workflows/_e2e_tests.yml
@@ -116,4 +116,4 @@ jobs:
           ADMIN_HF_ORGANIZATION: "valid_org"
           E2E_ADMIN_USER_TOKEN: "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"
         run: |
-          poetry run python -m pytest --memray -vv -s tests
+          poetry run python -m pytest -vv -s tests

--- a/.github/workflows/_unit-tests-python.yml
+++ b/.github/workflows/_unit-tests-python.yml
@@ -59,4 +59,4 @@ jobs:
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
           CLOUDFRONT_KEY_PAIR_ID: "K3814DK2QUJ71H"
           CLOUDFRONT_PRIVATE_KEY: ${{ secrets.CLOUDFRONT_PRIVATE_KEY }}
-        run: poetry run python -m pytest --memray -s
+        run: poetry run python -m pytest -s

--- a/services/admin/Makefile
+++ b/services/admin/Makefile
@@ -24,9 +24,9 @@ watch:
 test:
 	$(MAKE) down
 	$(MAKE) up
-	$(POETRY) run python -m pytest --memray -vv -x ${ADDOPTS} $(TEST_PATH)
+	$(POETRY) run python -m pytest -vv -x ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/admin.prometheus
 	mkdir /tmp/admin.prometheus
-	PROMETHEUS_MULTIPROC_DIR=/tmp/admin.prometheus $(POETRY) run python -m pytest --memray -vv -x -k "test_metrics" ${ADDOPTS} $(TEST_PATH)
+	PROMETHEUS_MULTIPROC_DIR=/tmp/admin.prometheus $(POETRY) run python -m pytest -vv -x -k "test_metrics" ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/admin.prometheus
 	$(MAKE) down

--- a/services/api/Makefile
+++ b/services/api/Makefile
@@ -24,9 +24,9 @@ watch:
 test:
 	$(MAKE) down
 	$(MAKE) up
-	$(POETRY) run python -m pytest --memray -vv -x ${ADDOPTS} $(TEST_PATH)
+	$(POETRY) run python -m pytest -vv -x ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/api.prometheus
 	mkdir /tmp/api.prometheus
-	PROMETHEUS_MULTIPROC_DIR=/tmp/api.prometheus $(POETRY) run python -m pytest --memray -vv -x -k "test_metrics" ${ADDOPTS} $(TEST_PATH)
+	PROMETHEUS_MULTIPROC_DIR=/tmp/api.prometheus $(POETRY) run python -m pytest -vv -x -k "test_metrics" ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/api.prometheus
 	$(MAKE) down

--- a/services/rows/Makefile
+++ b/services/rows/Makefile
@@ -24,9 +24,9 @@ watch:
 test:
 	$(MAKE) down
 	$(MAKE) up
-	$(POETRY) run python -m pytest --memray -vv -x ${ADDOPTS} $(TEST_PATH)
+	$(POETRY) run python -m pytest -vv -x ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/rows.prometheus
 	mkdir /tmp/rows.prometheus
-	PROMETHEUS_MULTIPROC_DIR=/tmp/rows.prometheus $(POETRY) run python -m pytest --memray -vv -x -k "test_metrics" ${ADDOPTS} $(TEST_PATH)
+	PROMETHEUS_MULTIPROC_DIR=/tmp/rows.prometheus $(POETRY) run python -m pytest -vv -x -k "test_metrics" ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/rows.prometheus
 	$(MAKE) down

--- a/services/search/Makefile
+++ b/services/search/Makefile
@@ -25,9 +25,9 @@ watch:
 test:
 	$(MAKE) down
 	$(MAKE) up
-	$(POETRY) run python -m pytest --memray -vv -x ${ADDOPTS} $(TEST_PATH)
+	$(POETRY) run python -m pytest -vv -x ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/search.prometheus
 	mkdir /tmp/search.prometheus
-	PROMETHEUS_MULTIPROC_DIR=/tmp/search.prometheus $(POETRY) run python -m pytest --memray -vv -x -k "test_metrics" ${ADDOPTS} $(TEST_PATH)
+	PROMETHEUS_MULTIPROC_DIR=/tmp/search.prometheus $(POETRY) run python -m pytest -vv -x -k "test_metrics" ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/search.prometheus
 	$(MAKE) down

--- a/services/webhook/Makefile
+++ b/services/webhook/Makefile
@@ -24,9 +24,9 @@ watch:
 test:
 	$(MAKE) down
 	$(MAKE) up
-	$(POETRY) run python -m pytest --memray -vv -x ${ADDOPTS} $(TEST_PATH)
+	$(POETRY) run python -m pytest -vv -x ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/webhook.prometheus
 	mkdir /tmp/webhook.prometheus
-	PROMETHEUS_MULTIPROC_DIR=/tmp/webhook.prometheus $(POETRY) run python -m pytest --memray -vv -x -k "test_metrics" ${ADDOPTS} $(TEST_PATH)
+	PROMETHEUS_MULTIPROC_DIR=/tmp/webhook.prometheus $(POETRY) run python -m pytest -vv -x -k "test_metrics" ${ADDOPTS} $(TEST_PATH)
 	rm -rf /tmp/webhook.prometheus
 	$(MAKE) down

--- a/tools/PythonTest.mk
+++ b/tools/PythonTest.mk
@@ -4,11 +4,11 @@ TEST_PATH ?= tests
 test:
 	$(MAKE) down
 	$(MAKE) up
-	$(POETRY) run python -m pytest --memray -vv -x ${ADDOPTS} $(TEST_PATH)
+	$(POETRY) run python -m pytest -vv -x ${ADDOPTS} $(TEST_PATH)
 	$(MAKE) down
 
 .PHONY: debug
 debug:
 	$(MAKE) up
-	$(POETRY) run python -m pytest --memray -vv -x --log-cli-level=DEBUG --capture=tee-sys --pdb ${ADDOPTS} $(TEST_PATH)
+	$(POETRY) run python -m pytest -vv -x --log-cli-level=DEBUG --capture=tee-sys --pdb ${ADDOPTS} $(TEST_PATH)
 	$(MAKE) down


### PR DESCRIPTION
Fix skipped async tests caused by pytest-memray: do not pass memray argument to pytest.

Fix #2901.