### PR TITLE
dataset-filetypes is not a small step

### DIFF
--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -722,7 +722,7 @@ specification: ProcessingGraphSpecification = {
         "input_type": "dataset",
         # no "triggered_by" <- this is a root step
         "job_runner_version": 1,
-        "difficulty": 20,
+        "difficulty": 50,
     },
 }
 


### PR DESCRIPTION
It has to do HTTP requests, it can manage big objects, and it depends on `datasets`. So... it might be better to process it with "medium" workers, not "light" ones that generally only transform cached entries.