### PR TITLE
Do not propagate error for is valid and hub cache

### DIFF
--- a/libs/libcommon/src/libcommon/processing_graph.py
+++ b/libs/libcommon/src/libcommon/processing_graph.py
@@ -610,7 +610,7 @@ specification: ProcessingGraphSpecification = {
             "dataset-config-names",  # required in case the dataset has no configs (error in previous step)
             "config-is-valid",
         ],
-        "job_runner_version": 7,
+        "job_runner_version": 8,
         "difficulty": 20,
     },
     "split-image-url-columns": {
@@ -697,7 +697,7 @@ specification: ProcessingGraphSpecification = {
             "dataset-compatible-libraries",
             "dataset-modalities",
         ],
-        "job_runner_version": 2,
+        "job_runner_version": 3,
         "difficulty": 20,
     },
     "dataset-compatible-libraries": {

--- a/services/worker/src/worker/job_runners/dataset/hub_cache.py
+++ b/services/worker/src/worker/job_runners/dataset/hub_cache.py
@@ -39,7 +39,7 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
 
     preview = False
     viewer = False
-    progresses: list[float] = []
+    progresses: list[Optional[float]] = []
     try:
         is_valid_response = get_previous_step_or_raise(kind="dataset-is-valid", dataset=dataset)
         content = is_valid_response["content"]

--- a/services/worker/src/worker/job_runners/dataset/hub_cache.py
+++ b/services/worker/src/worker/job_runners/dataset/hub_cache.py
@@ -2,6 +2,7 @@
 # Copyright 2023 The HuggingFace Authors.
 
 import logging
+from typing import Optional
 
 from libcommon.exceptions import PreviousStepFormatError
 from libcommon.simple_cache import CachedArtifactNotFoundError, get_previous_step_or_raise
@@ -36,21 +37,31 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
     """
     logging.info(f"compute 'dataset-hub-cache' for {dataset=}")
 
-    is_valid_response = get_previous_step_or_raise(kind="dataset-is-valid", dataset=dataset)
-    content = is_valid_response["content"]
-    if (
-        "preview" not in content
-        or not isinstance(content["preview"], bool)
-        or "viewer" not in content
-        or not isinstance(content["viewer"], bool)
-    ):
-        raise PreviousStepFormatError(
-            "Previous step 'dataset-is-valid' did not return the expected content: 'preview', 'viewer' or 'progress'."
-        )
-    preview = content["preview"]
-    viewer = content["viewer"]
-    is_valid_progress = is_valid_response["progress"]
+    preview = False
+    viewer = False
+    progresses: list[int] = []
+    try:
+        is_valid_response = get_previous_step_or_raise(kind="dataset-is-valid", dataset=dataset)
+        content = is_valid_response["content"]
+        if (
+            "preview" not in content
+            or not isinstance(content["preview"], bool)
+            or "viewer" not in content
+            or not isinstance(content["viewer"], bool)
+        ):
+            raise PreviousStepFormatError(
+                "Previous step 'dataset-is-valid' did not return the expected content: 'preview', 'viewer' or 'progress'."
+            )
+        preview = content["preview"]
+        viewer = content["viewer"]
+        progresses.append(is_valid_response["progress"])
+    except PreviousStepFormatError:
+        raise
+    except Exception:
+        logging.info(f"Missing 'dataset-is-valid' response for {dataset=}. We let the fields empty.")
 
+    partial = False
+    num_rows: Optional[int] = None
     try:
         size_response = get_previous_step_or_raise(kind="dataset-size", dataset=dataset)
         content = size_response["content"]
@@ -67,15 +78,11 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
             )
         partial = content["partial"]
         num_rows = content["size"]["dataset"]["num_rows"]
-        size_progress = size_response["progress"]
-    except (CachedArtifactNotFoundError, PreviousStepFormatError):
+        progresses.append(size_response["progress"])
+    except PreviousStepFormatError:
         raise
     except Exception:
-        partial = False
-        num_rows = None
-        size_progress = 0.0
-
-    progress = min((p for p in [is_valid_progress, size_progress] if p is not None), default=0.0)
+        logging.info(f"Missing 'dataset-size' response for {dataset=}. We let the fields empty.")
 
     tags: list[DatasetTag] = []
     libraries: list[DatasetLibrary] = []
@@ -89,6 +96,7 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
         compatible_libraries: list[CompatibleLibrary] = compatible_libraries_response["content"]["libraries"]
         libraries = [compatible_library["library"] for compatible_library in compatible_libraries]
         formats = compatible_libraries_response["content"].get("formats", [])
+        progresses.append(compatible_libraries_response["progress"])
     except CachedArtifactNotFoundError:
         logging.info(f"Missing 'dataset-compatible-libraries' response for {dataset=}")
     except KeyError:
@@ -101,6 +109,7 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
     try:
         modalities_response = get_previous_step_or_raise(kind="dataset-modalities", dataset=dataset)
         modalities = modalities_response["content"]["modalities"]
+        progresses.append(modalities_response["progress"])
     except CachedArtifactNotFoundError:
         logging.info(f"Missing 'dataset-modalities' response for {dataset=}")
     except KeyError:
@@ -121,7 +130,7 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
             formats=formats,
             modalities=modalities,
         ),
-        progress,
+        min([0.0 if p is None else p for p in progresses], default=0.0),
     )
 
 

--- a/services/worker/src/worker/job_runners/dataset/hub_cache.py
+++ b/services/worker/src/worker/job_runners/dataset/hub_cache.py
@@ -39,7 +39,7 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
 
     preview = False
     viewer = False
-    progresses: list[int] = []
+    progresses: list[float] = []
     try:
         is_valid_response = get_previous_step_or_raise(kind="dataset-is-valid", dataset=dataset)
         content = is_valid_response["content"]

--- a/services/worker/src/worker/job_runners/dataset/is_valid.py
+++ b/services/worker/src/worker/job_runners/dataset/is_valid.py
@@ -31,16 +31,23 @@ def compute_is_valid_response(dataset: str) -> tuple[IsValidResponse, float]:
     """
     logging.info(f"compute 'dataset-is-valid' response for {dataset=}")
 
-    config_names_response = get_previous_step_or_raise(kind="dataset-config-names", dataset=dataset)
-    content = config_names_response["content"]
-    if "config_names" not in content:
-        raise PreviousStepFormatError("Previous step did not return the expected content: 'config_names'.")
-
     preview = False
     viewer = False
     search = False
     filter = False
     statistics = False
+
+    try:
+        config_names_response = get_previous_step_or_raise(kind="dataset-config-names", dataset=dataset)
+    except Exception:
+        return (
+            IsValidResponse(preview=preview, viewer=viewer, search=search, filter=filter, statistics=statistics),
+            0.0,
+        )
+    content = config_names_response["content"]
+    if "config_names" not in content:
+        raise PreviousStepFormatError("Previous step did not return the expected content: 'config_names'.")
+
     try:
         total = 0
         pending = 0


### PR DESCRIPTION
We always want to have a "status", even if some of the previous steps are not available.