### PR TITLE
Use current priority for children jobs

### DIFF
--- a/libs/libcommon/src/libcommon/orchestrator.py
+++ b/libs/libcommon/src/libcommon/orchestrator.py
@@ -902,7 +902,10 @@ def finish_job(
     )
     logging.debug("the job output has been written to the cache.")
     # finish the job
-    Queue().finish_job(job_id=job_info["job_id"])
+    job_priority = Queue().finish_job(job_id=job_info["job_id"])
+    if job_priority:
+        job_info["priority"] = job_priority
+        # ^ change the priority of children jobs if the priority was updated during the job
     logging.debug("the job has been finished.")
     # trigger the next steps
     plan = AfterJobPlan(job_info=job_info, processing_graph=processing_graph, failed_runs=failed_runs)

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -963,10 +963,10 @@ class Queue:
             job = self._get_started_job(job_id=job_id)
         except DoesNotExist:
             logging.error(f"job {job_id} does not exist. Aborting.")
-            return
+            return None
         except StartedJobError as e:
             logging.error(f"job {job_id} has not the expected format for a started job. Aborting: {e}")
-            return
+            return None
         decrease_metric(job_type=job.type, status=job.status, difficulty=job.difficulty)
         job_priority = job.priority
         job.delete()

--- a/libs/libcommon/src/libcommon/queue.py
+++ b/libs/libcommon/src/libcommon/queue.py
@@ -947,7 +947,7 @@ class Queue:
             return False
         return True
 
-    def finish_job(self, job_id: str) -> bool:
+    def finish_job(self, job_id: str) -> Optional[Priority]:
         """Finish a job in the queue.
 
         The job is moved from the started state to the success or error state. The existing locks are released.
@@ -957,22 +957,22 @@ class Queue:
             is_success (`bool`): whether the job succeeded or not
 
         Returns:
-            `bool`: whether the job existed, and had the expected format (STARTED status, non-empty started_at)
-            before finishing
+            `Priority`, *optional*: the priority of the job, if the job was successfully finished.
         """
         try:
             job = self._get_started_job(job_id=job_id)
         except DoesNotExist:
             logging.error(f"job {job_id} does not exist. Aborting.")
-            return False
+            return
         except StartedJobError as e:
             logging.error(f"job {job_id} has not the expected format for a started job. Aborting: {e}")
-            return False
+            return
         decrease_metric(job_type=job.type, status=job.status, difficulty=job.difficulty)
+        job_priority = job.priority
         job.delete()
         release_locks(owner=job_id)
         # ^ bug: the lock owner is not set to the job id anymore when calling start_job()!
-        return True
+        return job_priority
 
     def delete_dataset_waiting_jobs(self, dataset: str) -> int:
         """

--- a/libs/libcommon/tests/test_orchestrator.py
+++ b/libs/libcommon/tests/test_orchestrator.py
@@ -202,6 +202,53 @@ def test_finish_job(
     assert cached_response.dataset_git_revision == REVISION_NAME
 
 
+@pytest.mark.parametrize(
+    "processing_graph,artifacts_to_create",
+    [
+        (PROCESSING_GRAPH_FAN_IN_OUT, [ARTIFACT_CA_1, ARTIFACT_CA_2]),
+    ],
+)
+def test_finish_job_priority_update(
+    processing_graph: ProcessingGraph,
+    artifacts_to_create: list[str],
+) -> None:
+    Queue().add_job(
+        dataset=DATASET_NAME,
+        revision=REVISION_NAME,
+        config=None,
+        split=None,
+        job_type=STEP_DA,
+        priority=Priority.NORMAL,
+        difficulty=DIFFICULTY,
+    )
+    job_info = Queue().start_job()
+    job_result = JobResult(
+        job_info=job_info,
+        job_runner_version=JOB_RUNNER_VERSION,
+        is_success=True,
+        output=JobOutput(
+            content=CONFIG_NAMES_CONTENT,
+            http_status=HTTPStatus.OK,
+            error_code=None,
+            details=None,
+            progress=1.0,
+        ),
+    )
+    # update the priority of the started job before it finishes
+    JobDocument(dataset=DATASET_NAME, pk=job_info["job_id"]).update(priority=Priority.HIGH)
+    # then finish
+    finish_job(job_result=job_result, processing_graph=processing_graph)
+
+    assert JobDocument.objects(dataset=DATASET_NAME).count() == len(artifacts_to_create)
+
+    done_job = JobDocument.objects(dataset=DATASET_NAME, status=Status.STARTED)
+    assert done_job.count() == 0
+
+    waiting_jobs = JobDocument.objects(dataset=DATASET_NAME, status=Status.WAITING)
+    assert waiting_jobs.count() == len(artifacts_to_create)
+    assert all(job.priority == Priority.HIGH for job in waiting_jobs)
+
+
 def populate_queue() -> None:
     Queue().create_jobs(
         [


### PR DESCRIPTION
When we change the priority of a job manually after it has started, we want the children jobs to use the same priority