### PR TITLE
Fix estimate info for zip datasets

### DIFF
--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -44,6 +44,7 @@ from datasets.utils.py_utils import asdict, map_nested
 from fsspec.core import url_to_fs
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.implementations.local import LocalFileOpener, LocalFileSystem
+from fsspec.implementations.zip import ZipFileSystem
 from fsspec.spec import AbstractBufferedFile
 from huggingface_hub import HfFileSystem
 from huggingface_hub._commit_api import (
@@ -880,6 +881,11 @@ def get_urlpaths_in_gen_kwargs(gen_kwargs: dict[str, Any]) -> list[str]:
     for shard in shards:
         if isinstance(shard, str):
             urlpaths.add(shard.split("::")[-1])
+        if shard and isinstance(shard, tuple):
+            if isinstance(shard[-1], FilesIterable):
+                urlpaths.update(item.split("::")[-1] for item in shard[-1])
+            elif shard[-1] and isinstance(shard[-1][0], str):
+                urlpaths.update(item.split("::")[-1] for item in shard[-1])
         elif isinstance(shard, FilesIterable):
             urlpaths.update(item.split("::")[-1] for item in shard)
         elif isinstance(shard, ArchiveIterable) and shard.args and isinstance(shard.args[0], str):
@@ -938,6 +944,7 @@ class track_reads:
     def __init__(self) -> None:
         self.files: dict[str, dict[str, int]] = {}
         self.exit_stack = ExitStack()
+        self._no_tracking = False
 
     def track_read(self, urlpath: str, f_read: Callable[..., ReadOutput], *args: Any, **kwargs: Any) -> ReadOutput:
         out = f_read(*args, **kwargs)
@@ -950,6 +957,20 @@ class track_reads:
         for out in f_iter():
             self.files[urlpath]["read"] += len(out)
             yield out
+
+    def track_metadata_read_once(self, instance: Any, func: Callable[..., T], **kwargs: Any) -> T:
+        urlpath = kwargs.pop("fo", "")
+        urlpath = url_to_fs(urlpath)[0].unstrip_protocol(urlpath)
+        previous_read = 0
+        if urlpath in self.files:
+            previous_read = self.files[urlpath]["read"]
+        out = func(instance, fo=urlpath, **kwargs)
+        if urlpath in self.files:
+            if "metadata_read" in self.files[urlpath]:
+                self.files[urlpath]["read"] = previous_read
+            else:
+                self.files[urlpath]["metadata_read"] = self.files[urlpath]["read"] - previous_read
+        return out
 
     def __enter__(self) -> "track_reads":
         tracker = self
@@ -978,7 +999,8 @@ class track_reads:
                     f.readline = functools.partial(tracker.track_read, urlpath, f.readline)
                 if hasattr(f, "readlines"):
                     f.readlines = functools.partial(tracker.track_read, urlpath, f.readlines)
-                tracker.files[urlpath] = {"read": 0, "size": int(f.size)}
+                if urlpath not in tracker.files:
+                    tracker.files[urlpath] = {"read": 0, "size": int(f.size)}
             return f
 
         # Use an exit_stack to be able to un-do all the replacements once the track_reads context ends.
@@ -995,6 +1017,10 @@ class track_reads:
         mock_hf_open.side_effect = functools.partial(wrapped, fs_open=hf_open)
         # always use fsspec even for local paths
         self.exit_stack.enter_context(patch("datasets.utils.file_utils.is_local_path", return_value=False))
+        # zip central directories are read over and over again, let's track it only once
+        zip_init = ZipFileSystem.__init__
+        mock_zip_init = self.exit_stack.enter_context(patch.object(ZipFileSystem, "__init__", autospec=True))
+        mock_zip_init.side_effect = functools.partial(self.track_metadata_read_once, func=zip_init)
         return self
 
     def __exit__(
@@ -1109,11 +1135,14 @@ def stream_convert_to_parquet(
                 partial = partial or limiter.total_bytes >= max_dataset_size_bytes
                 # estimate num_examples if partial conversion
                 urlpaths = get_urlpaths_in_gen_kwargs(splits_generators[split].gen_kwargs)
+                if limiter.total_bytes >= max_dataset_size_bytes and not urlpaths:
+                    logging.info(f"Unable to estimate {split} info (empty urlpaths list from gen_kwargs)")
                 if limiter.total_bytes >= max_dataset_size_bytes and urlpaths:
                     shards_total_read = sum(
                         reads_tracker.files[urlpath]["read"] for urlpath in urlpaths if urlpath in reads_tracker.files
                     )
                     if shards_total_read > 0:
+                        logging.info(f"Estimating {split} info from tracked reads ({shards_total_read} bytes)")
                         shards_total_size = (
                             len(urlpaths)
                             / min(10_000, len(urlpaths))
@@ -1128,6 +1157,8 @@ def stream_convert_to_parquet(
                             )
                         )
                         estimated_info["download_size"] += shards_total_size
+                    else:
+                        logging.info(f"Unable to estimate {split} info (empty tracked reads)")
     builder.info.splits = split_dict
     builder.info.dataset_size = sum(split.num_bytes for split in builder.info.splits.values())
     builder.info.download_size = None

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -944,7 +944,6 @@ class track_reads:
     def __init__(self) -> None:
         self.files: dict[str, dict[str, int]] = {}
         self.exit_stack = ExitStack()
-        self._no_tracking = False
 
     def track_read(self, urlpath: str, f_read: Callable[..., ReadOutput], *args: Any, **kwargs: Any) -> ReadOutput:
         out = f_read(*args, **kwargs)

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -41,7 +41,7 @@ from datasets.utils.file_utils import (
     url_or_path_join,
 )
 from datasets.utils.py_utils import asdict, map_nested
-from fsspec.core import url_to_fs
+from fsspec.core import filesystem, url_to_fs
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.implementations.local import LocalFileOpener, LocalFileSystem
 from fsspec.implementations.zip import ZipFileSystem
@@ -960,7 +960,8 @@ class track_reads:
 
     def track_metadata_read_once(self, instance: Any, func: Callable[..., T], **kwargs: Any) -> T:
         urlpath = kwargs.pop("fo", "")
-        urlpath = url_to_fs(urlpath)[0].unstrip_protocol(urlpath)
+        target_protocol = kwargs["target_protocol"]
+        urlpath = filesystem(target_protocol).unstrip_protocol(urlpath)
         previous_read = 0
         if urlpath in self.files:
             previous_read = self.files[urlpath]["read"]

--- a/services/worker/tests/fixtures/files.py
+++ b/services/worker/tests/fixtures/files.py
@@ -86,6 +86,16 @@ def zip_file(tmp_path_factory: pytest.TempPathFactory, text_file: str) -> str:
 
 
 @pytest.fixture(scope="session")
+def tar_file(tmp_path_factory: pytest.TempPathFactory, text_file: str) -> str:
+    import tarfile
+
+    path = str(tmp_path_factory.mktemp("data") / "file.txt.tar")
+    with tarfile.TarFile(path, "w") as f:
+        f.add(text_file, arcname=os.path.basename(text_file))
+    return path
+
+
+@pytest.fixture(scope="session")
 def extra_fields_readme(tmp_path_factory: pytest.TempPathFactory) -> str:
     path = str(tmp_path_factory.mktemp("data") / "README.md")
     lines = [

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -783,16 +783,15 @@ def test_stream_convert_to_parquet_generatorbasedbuilder(
 
 
 def test_stream_convert_to_parquet_estimate_info(tmp_path: Path, csv_path: str) -> None:
-    num_rows = 100
     expected_estimated_num_rows = 54
 
     def generate_from_text(text_files: list[str]) -> Iterator[dict[str, int]]:
         for text_file in text_files:
-            with fsspec.open(text_file, "r").open() as f:  # we track fsspec reads to estimate
+            with fsspec.open(text_file, "r") as f:  # we track fsspec reads to estimate
                 yield {"text": f.read()}
 
     cache_dir = str(tmp_path / "test_limit_parquet_writes_cache_dir")
-    gen_kwargs = {"text_files": [csv_path] * num_rows}
+    gen_kwargs = {"text_files": [csv_path]}
     builder = ParametrizedGeneratorBasedBuilder(
         generator=generate_from_text, cache_dir=cache_dir, gen_kwargs=gen_kwargs
     )

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -812,7 +812,7 @@ def test_stream_convert_to_parquet_estimate_info(tmp_path: Path, csv_path: str) 
 
 def test_stream_convert_to_parquet_estimate_info_zipped(tmp_path: Path, csv_path: str) -> None:
     num_rows = 100
-    expected_estimated_num_rows = 142
+    expected_estimated_num_rows = 140
 
     def generate_from_text(text_files: list[str]) -> Iterator[dict[str, int]]:
         for text_file in text_files:
@@ -1045,6 +1045,8 @@ def test_track_reads_zip_file(text_file: str, zip_file: str) -> None:
             open(text_file, "rb") as uncompressed_f,
         ):
             expected_output_size = len(uncompressed_f.read())
+            tracker.files["file://" + zip_file]["read"] > 0  # open does read metadata
+            assert tracker.files["file://" + zip_file]["metadata_read"] > 0
             assert len(f.read()) == expected_output_size
             assert "file://" + zip_file in tracker.files
             assert tracker.files["file://" + zip_file]["read"] != expected_output_size

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -21,7 +21,7 @@ import pandas as pd
 import pyarrow.parquet as pq
 import pytest
 import requests
-from datasets import Audio, Features, Image, Value, load_dataset, load_dataset_builder
+from datasets import Audio, Features, Image, StreamingDownloadManager, Value, load_dataset, load_dataset_builder
 from datasets.packaged_modules.generator.generator import (
     Generator as ParametrizedGeneratorBasedBuilder,
 )
@@ -49,6 +49,7 @@ from worker.job_runners.config.parquet_and_info import (
     create_commits,
     fill_builder_info,
     get_delete_operations,
+    get_urlpaths_in_gen_kwargs,
     get_writer_batch_size_from_info,
     get_writer_batch_size_from_row_group_size,
     limit_parquet_writes,
@@ -67,6 +68,7 @@ from ...fixtures.hub import HubDatasetTest
 from ..utils import REVISION_NAME
 
 GetJobRunner = Callable[[str, str, AppConfig], ConfigParquetAndInfoJobRunner]
+streaming_dl_manager = StreamingDownloadManager()
 
 
 @pytest.fixture
@@ -780,6 +782,58 @@ def test_stream_convert_to_parquet_generatorbasedbuilder(
             sum(pq.ParquetFile(parquet_file.local_file).read().nbytes for parquet_file in parquet_files)
             < expected_max_dataset_size_bytes
         )
+
+
+@pytest.mark.parametrize(
+    "gen_kwargs,expected",
+    [
+        (
+            {
+                "files": [
+                    streaming_dl_manager.iter_files("tmp://data"),
+                    streaming_dl_manager.iter_files("zip://::tmp://data.zip"),
+                ]
+            },
+            ["tmp://data", "tmp://data.zip"],
+        ),  # arrow, csv, json, parquet, text builders
+        (
+            {
+                "metadata_files": {"tmp://metadata"},
+                "split_name": "train",
+                "add_metadata": True,
+                "add_labels": False,
+                "files": [
+                    ("tmp://data", streaming_dl_manager.iter_files("tmp://data")),
+                    (None, streaming_dl_manager.iter_files("zip://::tmp://data.zip")),
+                ],
+            },
+            ["tmp://data", "tmp://data.zip"],
+        ),  # audiofolder, imagefolder builders
+        (
+            {
+                "tar_paths": [
+                    "tmp://data.tar",
+                ],
+                "tar_iterators": [
+                    streaming_dl_manager.iter_archive("tmp://data.tar"),
+                ],
+            },
+            ["tmp://data.tar"],
+        ),  # arrow, csv, json, parquet, text builders
+    ],
+)
+def test_get_urlpaths_in_gen_kwargs(
+    gen_kwargs: dict[str, Any],
+    expected: list[str],
+    tmpfs: fsspec.AbstractFileSystem,
+    csv_path: str,
+    zip_file: str,
+    tar_file: str,
+) -> None:
+    tmpfs.put(csv_path, "data")
+    tmpfs.put(zip_file, "data.zip")
+    tmpfs.put(tar_file, "data.tar")
+    assert get_urlpaths_in_gen_kwargs(gen_kwargs) == expected
 
 
 def test_stream_convert_to_parquet_estimate_info(tmp_path: Path, csv_path: str) -> None:

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -1044,7 +1044,7 @@ def test_track_reads_zip_file(text_file: str, zip_file: str) -> None:
             open(text_file, "rb") as uncompressed_f,
         ):
             expected_output_size = len(uncompressed_f.read())
-            tracker.files["file://" + zip_file]["read"] > 0  # open does read metadata
+            assert tracker.files["file://" + zip_file]["read"] > 0  # open does read metadata
             assert tracker.files["file://" + zip_file]["metadata_read"] > 0
             assert len(f.read()) == expected_output_size
             assert "file://" + zip_file in tracker.files


### PR DESCRIPTION
I simply had to track metadata reads only once to fix the estimator.

(otherwise every file opened in a zip archive triggers an additional read of the metadata with the central directory of the zip file that prevents the estimator from converging)

ex: locally and on only 100MB of parquet conversion (prod is 5GB), it estimates 47871 examples on https://huggingface.co/datasets/datasets-maintainers/test_many_zip_with_images_MSCOCO_zip (true value is exactly 50k)

Unrelared, but I noticed that parquet conversion of zip files is super slooooooowww, we'll have to improve that at one point because it can surely take more than 40min to run. When tested in prod, an error happens before that though (JobManagerCrashedError) which suggests a termination by kubernetes.