### PR TITLE
Do not keep DataFrames in memory in orchestrator classes

### DIFF
--- a/libs/libcommon/src/libcommon/orchestrator.py
+++ b/libs/libcommon/src/libcommon/orchestrator.py
@@ -400,6 +400,8 @@ class AfterJobPlan(Plan):
             self.add_task(DeleteWaitingJobsTask(jobs_df=self.pending_jobs_df))
         if self.job_infos_to_create:
             self.add_task(CreateJobsTask(job_infos=self.job_infos_to_create))
+        self.pending_jobs_df = None
+        self.job_infos_to_create = None
 
     def update(
         self,

--- a/libs/libcommon/src/libcommon/orchestrator.py
+++ b/libs/libcommon/src/libcommon/orchestrator.py
@@ -137,7 +137,7 @@ class CreateJobsTask(Task):
 
 @dataclass
 class DeleteWaitingJobsTask(Task):
-    job_ids: list[str]
+    job_ids: list[str] = field(init=False)
     jobs_df: InitVar[pd.DataFrame]
 
     def __post_init__(self, jobs_df: pd.DataFrame) -> None:

--- a/libs/libcommon/src/libcommon/orchestrator.py
+++ b/libs/libcommon/src/libcommon/orchestrator.py
@@ -400,8 +400,8 @@ class AfterJobPlan(Plan):
             self.add_task(DeleteWaitingJobsTask(jobs_df=self.pending_jobs_df))
         if self.job_infos_to_create:
             self.add_task(CreateJobsTask(job_infos=self.job_infos_to_create))
-        self.pending_jobs_df = None
-        self.job_infos_to_create = None
+        del self.pending_jobs_df
+        del self.job_infos_to_create
 
     def update(
         self,


### PR DESCRIPTION
Do not keep unnecessary DataFrames in memory in orchestrator classes and instead forward them for use only in class instantiation or reset them after being forwarded.

This PR is related to:
- #2921