### PR TITLE
Increase blockage duration

### DIFF
--- a/jobs/mongodb_migration/src/mongodb_migration/collector.py
+++ b/jobs/mongodb_migration/src/mongodb_migration/collector.py
@@ -1,11 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The HuggingFace Authors.
 
-from libcommon.constants import CACHE_METRICS_COLLECTION, TYPE_AND_STATUS_JOB_COUNTS_COLLECTION
+from libcommon.constants import (
+    CACHE_METRICS_COLLECTION,
+    QUEUE_COLLECTION_DATASET_BLOCKAGES,
+    QUEUE_COLLECTION_PAST_JOBS,
+    QUEUE_MONGOENGINE_ALIAS,
+    TYPE_AND_STATUS_JOB_COUNTS_COLLECTION,
+)
 
 from mongodb_migration.deletion_migrations import (
     CacheDeletionMigration,
     MetricsDeletionMigration,
+    MigrationDeleteIndex,
     MigrationDeleteJobsByStatus,
     MigrationQueueDeleteTTLIndex,
     MigrationRemoveFieldFromCache,
@@ -363,5 +370,19 @@ class MigrationsCollector:
             MigrationAddEstimatedDatasetInfoToParquetAndInfoCacheResponse(
                 version="20240619124500",
                 description="add 'estimated_dataset_info' field to config-parquet-and-info cache records",
+            ),
+            MigrationDeleteIndex(
+                version="20240624120300",
+                description="delete the TTL index in the pastJobs collection",
+                database=QUEUE_MONGOENGINE_ALIAS,
+                collection=QUEUE_COLLECTION_PAST_JOBS,
+                index_name="PAST_JOB_EXPIRE_AFTER_SECONDS",
+            ),
+            MigrationDeleteIndex(
+                version="20240624120301",
+                description="delete the TTL index in the blockedDatasets collection",
+                database=QUEUE_MONGOENGINE_ALIAS,
+                collection=QUEUE_COLLECTION_DATASET_BLOCKAGES,
+                index_name="DATASET_BLOCKAGE_EXPIRE_AFTER_SECONDS",
             ),
         ]

--- a/libs/libcommon/src/libcommon/queue/dataset_blockages.py
+++ b/libs/libcommon/src/libcommon/queue/dataset_blockages.py
@@ -34,7 +34,7 @@ class QuerySetManager(Generic[U]):
 # END monkey patching ### hack ###
 
 # delete the dataset blockage (ie. potentially unblock it) after 1 hour
-DATASET_BLOCKAGE_EXPIRE_AFTER_SECONDS = 1 * 60 * 60
+DATASET_BLOCKAGE_EXPIRE_AFTER_SECONDS = 1 * 60 * 60  # if we change this value, we have to delete the TTL index
 
 
 class DatasetBlockageDocument(Document):

--- a/libs/libcommon/src/libcommon/queue/dataset_blockages.py
+++ b/libs/libcommon/src/libcommon/queue/dataset_blockages.py
@@ -33,8 +33,10 @@ class QuerySetManager(Generic[U]):
 
 # END monkey patching ### hack ###
 
-# delete the dataset blockage (ie. potentially unblock it) after 1 hour
-DATASET_BLOCKAGE_EXPIRE_AFTER_SECONDS = 1 * 60 * 60  # if we change this value, we have to delete the TTL index
+# delete the dataset blockage (ie. potentially unblock it) after 6 hours
+DATASET_BLOCKAGE_EXPIRE_AFTER_SECONDS = (
+    6 * 60 * 60
+)  # if we change this value, we have to ensure the TTL index is migrated accordingly
 
 
 class DatasetBlockageDocument(Document):
@@ -52,7 +54,7 @@ class DatasetBlockageDocument(Document):
         "indexes": [
             ("dataset"),
             {
-                "name": "DATASET_BLOCKAGE_EXPIRE_AFTER_SECONDS",
+                "name": "DATASET_BLOCKAGE_EXPIRE_AFTER_SECONDS_BLUE",  # alternate BLUE/GREEN
                 "fields": ["blocked_at"],
                 "expireAfterSeconds": DATASET_BLOCKAGE_EXPIRE_AFTER_SECONDS,
             },

--- a/libs/libcommon/src/libcommon/queue/past_jobs.py
+++ b/libs/libcommon/src/libcommon/queue/past_jobs.py
@@ -34,14 +34,14 @@ class QuerySetManager(Generic[U]):
 
 # END monkey patching ### hack ###
 
-# we allow 2 hours of compute (parallel jobs) every hour, i.e. 2 dedicated machines
-MAX_MACHINES = 2
+# we allow 30 minutes of compute (parallel jobs) every hour, i.e. 0.5 dedicated machines
+MAX_MACHINES = 0.5
 # we look at the last 6 hours to decide to rate-limit a dataset
-RATE_LIMIT_WINDOW_SECONDS = 6 * 60 * 60
+RATE_LIMIT_WINDOW_SECONDS = 6 * 60 * 60  # if we change this value, we have to delete the TTL index
 # total jobs duration that triggers rate-limiting a dataset
 DATASET_BLOCKAGE_THRESHOLD_SECONDS = MAX_MACHINES * RATE_LIMIT_WINDOW_SECONDS
 # don't check for rate-limiting if the duration is super short
-JOB_DURATION_CHECK_MIN_SECONDS = 5 * 60
+JOB_DURATION_CHECK_MIN_SECONDS = 2 * 60
 # don't record short durations, because they will not have impact, but can clutter the collection
 JOB_DURATION_MIN_SECONDS = 30
 

--- a/libs/libcommon/src/libcommon/queue/past_jobs.py
+++ b/libs/libcommon/src/libcommon/queue/past_jobs.py
@@ -34,14 +34,16 @@ class QuerySetManager(Generic[U]):
 
 # END monkey patching ### hack ###
 
-# we allow 30 minutes of compute (parallel jobs) every hour, i.e. 0.5 dedicated machines
-MAX_MACHINES = 0.5
-# we look at the last 6 hours to decide to rate-limit a dataset
-RATE_LIMIT_WINDOW_SECONDS = 6 * 60 * 60  # if we change this value, we have to delete the TTL index
+# we allow 2 hours of compute (parallel jobs) every hour, i.e. 2 dedicated machines
+MAX_MACHINES = 2
+# we look at the last 1 hour to decide to rate-limit a dataset
+RATE_LIMIT_WINDOW_SECONDS = (
+    1 * 60 * 60
+)  # if we change this value, we have to ensure the TTL index is migrated accordingly
 # total jobs duration that triggers rate-limiting a dataset
 DATASET_BLOCKAGE_THRESHOLD_SECONDS = MAX_MACHINES * RATE_LIMIT_WINDOW_SECONDS
 # don't check for rate-limiting if the duration is super short
-JOB_DURATION_CHECK_MIN_SECONDS = 2 * 60
+JOB_DURATION_CHECK_MIN_SECONDS = 30
 # don't record short durations, because they will not have impact, but can clutter the collection
 JOB_DURATION_MIN_SECONDS = 30
 
@@ -60,7 +62,7 @@ class PastJobDocument(Document):
         "db_alias": QUEUE_MONGOENGINE_ALIAS,
         "indexes": [
             {
-                "name": "PAST_JOB_EXPIRE_AFTER_SECONDS",
+                "name": "PAST_JOB_EXPIRE_AFTER_SECONDS_BLUE",  # alternate BLUE/GREEN
                 "fields": ["finished_at"],
                 "expireAfterSeconds": RATE_LIMIT_WINDOW_SECONDS,
             },


### PR DESCRIPTION
blocked for 1h -> 6h
based on the last 6h -> 1h

The effect should be to block more datasets, more quickly, and for a longer time. Currently, all the resources are still dedicated to datasets that are updated every xxx minutes.