### PR TITLE
add cudf to toctree

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -36,6 +36,8 @@
           title: Overview
         - local: clickhouse
           title: ClickHouse
+        - local: cudf
+          title: cuDF
         - local: duckdb
           title: DuckDB
         - local: pandas


### PR DESCRIPTION
Follow up to https://github.com/huggingface/dataset-viewer/pull/2941

I realized the docs were not building in the CI: https://github.com/huggingface/dataset-viewer/actions/runs/9648374360/job/26609396615

Apologies for not checking this in my prior PR.

![Screenshot 2024-06-24 at 12 21 45 PM](https://github.com/huggingface/dataset-viewer/assets/17162724/9d7278b6-d00f-4795-93dc-259a08fb856b)
