### PR TITLE
update indexes

### DIFF
--- a/libs/libcommon/src/libcommon/queue/jobs.py
+++ b/libs/libcommon/src/libcommon/queue/jobs.py
@@ -163,8 +163,8 @@ class JobDocument(Document):
         "indexes": [
             ("dataset", "status"),
             ("type", "dataset", "status"),
-            ("priority", "status", "created_at", "namespace", "difficulty", "unicity_id"),
-            ("priority", "status", "created_at", "difficulty", "namespace"),
+            ("priority", "status", "created_at", "namespace", "difficulty", "dataset", "unicity_id"),
+            ("priority", "status", "created_at", "difficulty", "dataset", "namespace"),
             ("priority", "status", "type", "namespace", "unicity_id", "created_at", "-difficulty"),
             ("status", "type"),
             ("unicity_id", "status", "-created_at"),


### PR DESCRIPTION
I think the old ones will remain. I'll remove them manually...

These two indexes have been proposed by mongo cloud. The reason is: https://github.com/huggingface/dataset-viewer/pull/2933/files#diff-4c951d0a5e21ef5c719bc392169f41e726461028dfd8e049778fedff37ba38c8R422