### PR TITLE
Ignore blocked datasets in WorkerSize metrics for auto scaling

### DIFF
--- a/libs/libcommon/src/libcommon/queue/metrics.py
+++ b/libs/libcommon/src/libcommon/queue/metrics.py
@@ -15,6 +15,7 @@ from libcommon.constants import (
     WORKER_TYPE_JOB_COUNTS_COLLECTION,
 )
 from libcommon.dtos import Status, WorkerSize
+from libcommon.queue.dataset_blockages import get_blocked_datasets
 from libcommon.utils import get_datetime
 
 # START monkey patching ### hack ###
@@ -104,7 +105,7 @@ class WorkerSizeJobsCountDocument(Document):
     objects = QuerySetManager["WorkerSizeJobsCountDocument"]()
 
 
-def _update_metrics(job_type: str, status: str, increase_by: int, difficulty: int) -> None:
+def _update_metrics(dataset: str, job_type: str, status: str, increase_by: int, difficulty: int) -> None:
     JobTotalMetricDocument.objects(job_type=job_type, status=status).update(
         upsert=True,
         write_concern={"w": "majority", "fsync": True},
@@ -112,25 +113,34 @@ def _update_metrics(job_type: str, status: str, increase_by: int, difficulty: in
         inc__total=increase_by,
     )
     if status == Status.WAITING:
-        worker_size = WorkerSizeJobsCountDocument.get_worker_size(difficulty=difficulty)
-        WorkerSizeJobsCountDocument.objects(worker_size=worker_size).update(
-            upsert=True,
-            write_concern={"w": "majority", "fsync": True},
-            read_concern={"level": "majority"},
-            inc__jobs_count=increase_by,
-        )
+        # Do not consider blocked datasets for autoscaling metrics
+        blocked_datasets = get_blocked_datasets()
+        if dataset not in blocked_datasets:
+            worker_size = WorkerSizeJobsCountDocument.get_worker_size(difficulty=difficulty)
+            WorkerSizeJobsCountDocument.objects(worker_size=worker_size).update(
+                upsert=True,
+                write_concern={"w": "majority", "fsync": True},
+                read_concern={"level": "majority"},
+                inc__jobs_count=increase_by,
+            )
 
 
-def increase_metric(job_type: str, status: str, difficulty: int) -> None:
-    _update_metrics(job_type=job_type, status=status, increase_by=DEFAULT_INCREASE_AMOUNT, difficulty=difficulty)
+def increase_metric(dataset: str, job_type: str, status: str, difficulty: int) -> None:
+    _update_metrics(
+        dataset=dataset, job_type=job_type, status=status, increase_by=DEFAULT_INCREASE_AMOUNT, difficulty=difficulty
+    )
 
 
-def decrease_metric(job_type: str, status: str, difficulty: int) -> None:
-    _update_metrics(job_type=job_type, status=status, increase_by=DEFAULT_DECREASE_AMOUNT, difficulty=difficulty)
+def decrease_metric(dataset: str, job_type: str, status: str, difficulty: int) -> None:
+    _update_metrics(
+        dataset=dataset, job_type=job_type, status=status, increase_by=DEFAULT_DECREASE_AMOUNT, difficulty=difficulty
+    )
 
 
-def update_metrics_for_type(job_type: str, previous_status: str, new_status: str, difficulty: int) -> None:
+def update_metrics_for_type(
+    dataset: str, job_type: str, previous_status: str, new_status: str, difficulty: int
+) -> None:
     if job_type is not None:
-        decrease_metric(job_type=job_type, status=previous_status, difficulty=difficulty)
-        increase_metric(job_type=job_type, status=new_status, difficulty=difficulty)
+        decrease_metric(dataset=dataset, job_type=job_type, status=previous_status, difficulty=difficulty)
+        increase_metric(dataset=dataset, job_type=job_type, status=new_status, difficulty=difficulty)
         # ^ this does not affect WorkerSizeJobsCountDocument, so we don't pass the job difficulty

--- a/libs/libcommon/tests/queue/test_jobs.py
+++ b/libs/libcommon/tests/queue/test_jobs.py
@@ -450,9 +450,13 @@ def test_get_jobs_count_by_worker_size() -> None:
     test_type = "test_type"
     test_other_type = "test_other_type"
     test_dataset = "test_dataset"
+    test_blocked_dataset = "blocked_dataset"
     test_revision = "test_revision"
     queue = Queue()
 
+    assert queue.get_jobs_count_by_worker_size() == {"heavy": 0, "medium": 0, "light": 0}
+    block_dataset(test_blocked_dataset)
+    queue.add_job(job_type=test_type, dataset=test_blocked_dataset, revision=test_revision, difficulty=50)
     assert queue.get_jobs_count_by_worker_size() == {"heavy": 0, "medium": 0, "light": 0}
     queue.add_job(job_type=test_type, dataset=test_dataset, revision=test_revision, difficulty=50)
     assert queue.get_jobs_count_by_worker_size() == {"heavy": 0, "medium": 1, "light": 0}


### PR DESCRIPTION
Fix for https://github.com/huggingface/dataset-viewer/issues/2945