### PR TITLE
Add threshold to modalities from filetypes

### DIFF
--- a/services/worker/src/worker/job_runners/dataset/modalities.py
+++ b/services/worker/src/worker/job_runners/dataset/modalities.py
@@ -204,7 +204,7 @@ _3D_EXTENSIONS = {
 TEXT_EXTENSIONS = {
     ".txt",
 }
-OTHER_EXTENSIONS = {".parquet", ".csv", ".json", ".jsonl", ".arrow"}
+MULTI_ROWS_EXTENSIONS = {".parquet", ".csv", ".json", ".jsonl", ".arrow"}
 ALL_EXTENSIONS = (
     IMAGE_EXTENSIONS
     | AUDIO_EXTENSIONS
@@ -214,7 +214,7 @@ ALL_EXTENSIONS = (
     | GEOSPATIAL_EXTENSIONS
     | _3D_EXTENSIONS
     | TEXT_EXTENSIONS
-    | OTHER_EXTENSIONS
+    | MULTI_ROWS_EXTENSIONS
 )
 
 
@@ -245,10 +245,14 @@ def detect_modalities_from_filetypes(dataset: str) -> set[DatasetModality]:
         total_count = sum(
             filetype["count"] for filetype in content["filetypes"] if filetype["extension"] in ALL_EXTENSIONS
         )
+        has_multi_rows_files = any(
+            filetype["count"] for filetype in content["filetypes"] if filetype["extension"] in MULTI_ROWS_EXTENSIONS
+        )
         min_count = round(0.1 * total_count)
+        min_count_for_image = 10 if has_multi_rows_files else 1
         for filetype in content["filetypes"]:
             # we condition by a number of files (filetype["count"] > threshold) to avoid false positives
-            if filetype["count"] < min_count:
+            if filetype["count"] < (min_count_for_image if filetype["extension"] in IMAGE_EXTENSIONS else min_count):
                 continue
             if filetype["extension"] in IMAGE_EXTENSIONS:
                 modalities.add("image")

--- a/services/worker/src/worker/job_runners/dataset/modalities.py
+++ b/services/worker/src/worker/job_runners/dataset/modalities.py
@@ -248,11 +248,15 @@ def detect_modalities_from_filetypes(dataset: str) -> set[DatasetModality]:
         has_multi_rows_files = any(
             filetype["count"] for filetype in content["filetypes"] if filetype["extension"] in MULTI_ROWS_EXTENSIONS
         )
-        min_count = round(0.1 * total_count)
-        min_count_for_image = 10 if has_multi_rows_files else 1
+        min_count = round(0.1 * total_count)  # ignore files that are <10% of the data files to avoid false positives
+        min_count_for_image = (
+            10 if has_multi_rows_files else 1
+        )  # images are often used as figures in README, so we also add this threshold
         for filetype in content["filetypes"]:
             # we condition by a number of files (filetype["count"] > threshold) to avoid false positives
-            if filetype["count"] < (min_count_for_image if filetype["extension"] in IMAGE_EXTENSIONS else min_count):
+            if filetype["count"] < min_count:
+                continue
+            elif filetype["extension"] in IMAGE_EXTENSIONS and filetype["count"] < min_count_for_image:
                 continue
             if filetype["extension"] in IMAGE_EXTENSIONS:
                 modalities.add("image")

--- a/services/worker/tests/job_runners/dataset/test_modalities.py
+++ b/services/worker/tests/job_runners/dataset/test_modalities.py
@@ -140,6 +140,20 @@ UPSTREAM_RESPONSE_FILETYPES_TEXT: UpstreamResponse = UpstreamResponse(
     },
     progress=1.0,
 )
+UPSTREAM_RESPONSE_FILETYPES_IMAGE_AND_ONE_TEXT_FILE: UpstreamResponse = UpstreamResponse(
+    kind="dataset-filetypes",
+    dataset=IMAGE_DATASET,
+    dataset_git_revision=REVISION_NAME,
+    http_status=HTTPStatus.OK,
+    content={
+        "filetypes": [
+            {"extension": ".jpg", "count": 20},
+            {"extension": ".txt", "count": 1},  # shouldn't be taken into account since it's <10% of files
+        ],
+        "partial": False,
+    },
+    progress=1.0,
+)
 UPSTREAM_RESPONSE_FILETYPES_ALL: UpstreamResponse = UpstreamResponse(
     kind="dataset-filetypes",
     dataset=TEXT_DATASET,
@@ -286,6 +300,13 @@ def get_job_runner(
             IMAGE_DATASET,
             [
                 UPSTREAM_RESPONSE_INFO_NOT_TABULAR_1,
+            ],
+            EXPECTED_IMAGE,
+        ),
+        (
+            IMAGE_DATASET,
+            [
+                UPSTREAM_RESPONSE_FILETYPES_IMAGE_AND_ONE_TEXT_FILE,
             ],
             EXPECTED_IMAGE,
         ),


### PR DESCRIPTION
Fix modalities false positives for
- https://huggingface.co/datasets/chenxx1/jia
- https://huggingface.co/datasets/proj-persona/PersonaHub
- https://huggingface.co/datasets/BAAI/Infinity-Instruct
- https://huggingface.co/datasets/m-a-p/COIG-CQIA
- https://huggingface.co/datasets/Magpie-Align/Magpie-Pro-300K-Filtered

I added two thresholds to get less false positives:
- one general threshold to ignore file types that are <10% of the files
- one additional threshold specific to images in presence of csv/json/parquet, since images are often used in README as figures 

cc @severo 

This should take care of most false positives, and we can refine later if needed