### PR TITLE
remove the 'tags' field from the Hub cache response

### DIFF
--- a/services/api/README.md
+++ b/services/api/README.md
@@ -20,7 +20,7 @@ See https://huggingface.co/docs/datasets-server
 
 - /healthcheck: Ensure the app is running
 - /metrics: Return a list of metrics in the Prometheus format
-- /croissant: Return the [Croissant](https://huggingface.co/docs/datasets-server/croissant) metadata for a dataset.
+- /croissant-crumbs: Return (parts of) the [Croissant](https://huggingface.co/docs/datasets-server/croissant) metadata for a dataset.
 - /is-valid: Tell if a dataset is [valid](https://huggingface.co/docs/datasets-server/valid)
 - /splits: List the [splits](https://huggingface.co/docs/datasets-server/splits) names for a dataset
 - /first-rows: Extract the [first rows](https://huggingface.co/docs/datasets-server/first_rows) for a dataset split

--- a/services/worker/src/worker/dtos.py
+++ b/services/worker/src/worker/dtos.py
@@ -312,7 +312,6 @@ class IsValidResponse(TypedDict):
     statistics: bool
 
 
-DatasetTag = Literal["croissant"]
 DatasetLibrary = Literal["mlcroissant", "webdataset", "datasets", "pandas", "dask"]
 DatasetFormat = Literal["json", "csv", "parquet", "imagefolder", "audiofolder", "webdataset", "text"]
 ProgrammingLanguage = Literal["python"]
@@ -332,7 +331,6 @@ class CompatibleLibrary(TypedDict):
 
 
 class DatasetCompatibleLibrariesResponse(TypedDict):
-    tags: list[DatasetTag]
     libraries: list[CompatibleLibrary]
     formats: list[DatasetFormat]
 
@@ -349,7 +347,6 @@ class DatasetHubCacheResponse(TypedDict):
     viewer: bool
     partial: bool
     num_rows: Optional[int]
-    tags: list[DatasetTag]
     libraries: list[DatasetLibrary]
     modalities: list[DatasetModality]
     formats: list[DatasetFormat]

--- a/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
+++ b/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
@@ -38,7 +38,6 @@ from worker.dtos import (
     DatasetCompatibleLibrariesResponse,
     DatasetFormat,
     DatasetLibrary,
-    DatasetTag,
     LoadingCode,
 )
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunnerWithDatasetsCache
@@ -668,7 +667,6 @@ def compute_compatible_libraries_response(
         login_required = not HfFileSystem(token="no_token").isdir("datasets/" + dataset)  # nosec
     except NotImplementedError:  # hfh doesn't implement listing user's datasets
         pass
-    tags: list[DatasetTag] = []
     libraries: list[CompatibleLibrary] = []
     formats: list[DatasetFormat] = []
     infos: list[dict[str, Any]] = []
@@ -701,8 +699,7 @@ def compute_compatible_libraries_response(
         libraries.append(
             get_mlcroissant_compatible_library(dataset, infos, login_required=login_required, partial=partial)
         )
-        tags.append("croissant")
-    return DatasetCompatibleLibrariesResponse(tags=tags, libraries=libraries, formats=formats)
+    return DatasetCompatibleLibrariesResponse(libraries=libraries, formats=formats)
 
 
 class DatasetCompatibleLibrariesJobRunner(DatasetJobRunnerWithDatasetsCache):

--- a/services/worker/src/worker/job_runners/dataset/hub_cache.py
+++ b/services/worker/src/worker/job_runners/dataset/hub_cache.py
@@ -13,7 +13,6 @@ from worker.dtos import (
     DatasetHubCacheResponse,
     DatasetLibrary,
     DatasetModality,
-    DatasetTag,
     JobResult,
 )
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunner
@@ -88,7 +87,6 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
     except Exception:
         logging.info(f"Missing 'dataset-size' response for {dataset=}. We let the fields empty.")
 
-    tags: list[DatasetTag] = []
     libraries: list[DatasetLibrary] = []
     formats: list[DatasetFormat] = []
     modalities: list[DatasetModality] = []
@@ -96,7 +94,6 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
         compatible_libraries_response = get_previous_step_or_raise(
             kind="dataset-compatible-libraries", dataset=dataset
         )
-        tags = compatible_libraries_response["content"]["tags"]
         compatible_libraries: list[CompatibleLibrary] = compatible_libraries_response["content"]["libraries"]
         libraries = [compatible_library["library"] for compatible_library in compatible_libraries]
         formats = compatible_libraries_response["content"].get("formats", [])
@@ -105,7 +102,7 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
         logging.info(f"Missing 'dataset-compatible-libraries' response for {dataset=}")
     except KeyError:
         raise PreviousStepFormatError(
-            "Previous step 'dataset-compatible-libraries' did not return the expected content: 'tags', 'libraries'."
+            "Previous step 'dataset-compatible-libraries' did not return the expected content: 'libraries'."
         )
     except Exception:
         logging.info("Error while parsing 'dataset-compatible-libraries' response. We let the fields empty.")
@@ -129,7 +126,6 @@ def compute_hub_cache_response(dataset: str) -> tuple[DatasetHubCacheResponse, f
             viewer=viewer,
             partial=partial,
             num_rows=num_rows,
-            tags=tags,
             libraries=libraries,
             formats=formats,
             modalities=modalities,

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -73,7 +73,6 @@ UPSTREAM_RESPONSE_INFO_ERROR: UpstreamResponse = UpstreamResponse(
 )
 EXPECTED_PARQUET = (
     {
-        "tags": ["croissant"],
         "formats": ["parquet"],
         "libraries": [
             {
@@ -135,7 +134,6 @@ EXPECTED_PARQUET = (
 
 EXPECTED_PARQUET_LOGIN_REQUIRED = (
     {
-        "tags": ["croissant"],
         "formats": ["parquet"],
         "libraries": [
             {
@@ -201,7 +199,6 @@ EXPECTED_PARQUET_LOGIN_REQUIRED = (
 )
 EXPECTED_WEBDATASET = (
     {
-        "tags": ["croissant"],
         "formats": ["webdataset"],
         "libraries": [
             {

--- a/services/worker/tests/job_runners/dataset/test_hub_cache.py
+++ b/services/worker/tests/job_runners/dataset/test_hub_cache.py
@@ -11,7 +11,7 @@ from libcommon.resources import CacheMongoResource, QueueMongoResource
 from libcommon.simple_cache import upsert_response
 
 from worker.config import AppConfig
-from worker.dtos import DatasetFormat, DatasetHubCacheResponse, DatasetLibrary, DatasetModality, DatasetTag
+from worker.dtos import DatasetFormat, DatasetHubCacheResponse, DatasetLibrary, DatasetModality
 from worker.job_runners.dataset.hub_cache import DatasetHubCacheJobRunner
 
 from ..utils import REVISION_NAME, UpstreamResponse
@@ -26,7 +26,6 @@ def prepare_and_clean_mongo(app_config: AppConfig) -> None:
 GetJobRunner = Callable[[str, AppConfig], DatasetHubCacheJobRunner]
 
 DATASET = "dataset"
-TAG: DatasetTag = "croissant"
 LIBRARY: DatasetLibrary = "mlcroissant"
 FORMAT: DatasetFormat = "json"
 MODALITY: DatasetModality = "image"
@@ -75,7 +74,7 @@ UPSTREAM_RESPONSE_COMPATIBLE_LIBRARIES_OK: UpstreamResponse = UpstreamResponse(
     dataset=DATASET,
     dataset_git_revision=REVISION_NAME,
     http_status=HTTPStatus.OK,
-    content={"tags": [TAG], "libraries": [{"library": LIBRARY}], "formats": [FORMAT]},
+    content={"libraries": [{"library": LIBRARY}], "formats": [FORMAT]},
     progress=1.0,
 )
 UPSTREAM_RESPONSE_COMPATIBLE_LIBRARIES_ERROR: UpstreamResponse = UpstreamResponse(
@@ -91,7 +90,7 @@ UPSTREAM_RESPONSE_MODALITIES_OK: UpstreamResponse = UpstreamResponse(
     dataset=DATASET,
     dataset_git_revision=REVISION_NAME,
     http_status=HTTPStatus.OK,
-    content={"tags": [TAG], "modalities": [MODALITY]},
+    content={"modalities": [MODALITY]},
     progress=1.0,
 )
 UPSTREAM_RESPONSE_MODALITIES_ERROR: UpstreamResponse = UpstreamResponse(
@@ -108,7 +107,6 @@ EXPECTED_ALL_OK: tuple[DatasetHubCacheResponse, float] = (
         "preview": True,
         "partial": False,
         "num_rows": 1000,
-        "tags": [TAG],
         "libraries": [LIBRARY],
         "modalities": [MODALITY],
         "formats": [FORMAT],
@@ -121,7 +119,6 @@ EXPECTED_IS_VALID_AND_SIZE: tuple[DatasetHubCacheResponse, float] = (
         "preview": True,
         "partial": False,
         "num_rows": 1000,
-        "tags": [],
         "libraries": [],
         "modalities": [],
         "formats": [],
@@ -134,7 +131,6 @@ EXPECTED_NO_SIZE: tuple[DatasetHubCacheResponse, float] = (
         "preview": True,
         "partial": False,
         "num_rows": None,
-        "tags": [],
         "libraries": [],
         "modalities": [],
         "formats": [],
@@ -147,7 +143,6 @@ EXPECTED_OK_WITH_LIBRARIES_AND_FORMATS: tuple[DatasetHubCacheResponse, float] = 
         "preview": True,
         "partial": False,
         "num_rows": 1000,
-        "tags": [TAG],
         "libraries": [LIBRARY],
         "modalities": [],
         "formats": [FORMAT],
@@ -160,7 +155,6 @@ EXPECTED_NO_PROGRESS: tuple[DatasetHubCacheResponse, float] = (
         "preview": True,
         "partial": True,
         "num_rows": 1000,
-        "tags": [TAG],
         "libraries": [LIBRARY],
         "modalities": [MODALITY],
         "formats": [FORMAT],
@@ -173,7 +167,6 @@ EXPECTED_OK_WITH_MODALITIES: tuple[DatasetHubCacheResponse, float] = (
         "preview": True,
         "partial": False,
         "num_rows": 1000,
-        "tags": [],
         "libraries": [],
         "modalities": [MODALITY],
         "formats": [],
@@ -186,7 +179,6 @@ EXPECTED_EMPTY: tuple[DatasetHubCacheResponse, float] = (
         "preview": False,
         "partial": False,
         "num_rows": None,
-        "tags": [],
         "libraries": [],
         "modalities": [],
         "formats": [],
@@ -199,7 +191,6 @@ EXPECTED_ONLY_SIZE: tuple[DatasetHubCacheResponse, float] = (
         "preview": False,
         "partial": False,
         "num_rows": 1000,
-        "tags": [],
         "libraries": [],
         "modalities": [],
         "formats": [],
@@ -212,7 +203,6 @@ EXPECTED_ONLY_MODALITIES: tuple[DatasetHubCacheResponse, float] = (
         "preview": False,
         "partial": False,
         "num_rows": None,
-        "tags": [],
         "libraries": [],
         "modalities": [MODALITY],
         "formats": [],


### PR DESCRIPTION
Note that I don't migrate to remove the field from the cache (we could do it, but not sure it's worth the pain)

Better wait for https://github.com/huggingface-internal/moon-landing/pull/10591 (internal) to be deployed on the Hub before merging.