### PR TITLE
Ignore transformed data in split-duckdb-index when stats throws error

### DIFF
--- a/services/worker/src/worker/job_runners/split/duckdb_index.py
+++ b/services/worker/src/worker/job_runners/split/duckdb_index.py
@@ -323,7 +323,11 @@ def compute_split_duckdb_index_response(
     split_parquet_directory = duckdb_index_file_directory / config / split_directory
     all_split_parquets = str(split_parquet_directory / "*.parquet")
 
-    transformed_df = compute_transformed_data(split_parquet_directory, features)
+    transformed_df = None
+    try:
+        transformed_df = compute_transformed_data(split_parquet_directory, features)
+    except Exception as err:
+        logging.debug(f"Unable to compute transformed data {err}, skipping statistics.")
 
     # index all columns
     db_path = duckdb_index_file_directory.resolve() / index_filename


### PR DESCRIPTION
Part of https://github.com/huggingface/dataset-viewer/issues/1443:
Currently, we have 3054 cache entries with UnexpectedError because stats fail for some columns like:
```
    details: {
      error: 'expected str, bytes or os.PathLike object, not BytesIO',
      cause_exception: 'TypeError',
      cause_message: 'expected str, bytes or os.PathLike object, not BytesIO',
      cause_traceback: [
        'Traceback (most recent call last):\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/librosa/core/audio.py", line 803, in get_duration\n' +
          '    return sf.info(path).duration  # type: ignore\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/soundfile.py", line 467, in info\n' +
          '    return _SoundFileInfo(file, verbose)\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/soundfile.py", line 412, in __init__\n' +
          '    with SoundFile(file) as f:\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/soundfile.py", line 658, in __init__\n' +
          '    self._file = self._open(file, mode_int, closefd)\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/soundfile.py", line 1216, in _open\n' +
          '    raise LibsndfileError(err, prefix="Error opening {0!r}: ".format(self.name))\n',
        'soundfile.LibsndfileError: Error opening <_io.BytesIO object at 0x7f6f99e39db0>: Format not recognised.\n',
        '\n' +
          'During handling of the above exception, another exception occurred:\n' +
          '\n',
        'Traceback (most recent call last):\n',
        '  File "/src/services/worker/src/worker/job_manager.py", line 125, in process\n' +
          '    job_result = self.job_runner.compute()\n',
        '  File "/src/services/worker/src/worker/job_runners/split/duckdb_index.py", line 448, in compute\n' +
          '    compute_split_duckdb_index_response(\n',
        '  File "/src/services/worker/src/worker/job_runners/split/duckdb_index.py", line 278, in compute_split_duckdb_index_response\n' +
          '    transformed_df = compute_transformed_data(split_parquet_directory, features)\n',
        '  File "/src/services/worker/src/worker/job_runners/split/duckdb_index.py", line 161, in compute_transformed_data\n' +
          '    transformed_df = compute_audio_duration_column(parquet_directory, feature_name, transformed_df)\n',
        '  File "/src/services/worker/src/worker/job_runners/split/duckdb_index.py", line 124, in compute_audio_duration_column\n' +
          '    durations = AudioColumn.compute_transformed_data(parquet_directory, column_name, AudioColumn.get_duration)\n',
        '  File "/src/services/worker/src/worker/statistics_utils.py", line 606, in compute_transformed_data\n' +
          '    shard_transformed_values = thread_map(\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/tqdm/contrib/concurrent.py", line 69, in thread_map\n' +
          '    return _executor_map(ThreadPoolExecutor, fn, *iterables, **tqdm_kwargs)\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/tqdm/contrib/concurrent.py", line 51, in _executor_map\n' +
          '    return list(tqdm_class(ex.map(fn, *iterables, chunksize=chunksize), **kwargs))\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/tqdm/std.py", line 1181, in __iter__\n' +
          '    for obj in iterable:\n',
        '  File "/usr/local/lib/python3.9/concurrent/futures/_base.py", line 609, in result_iterator\n' +
          '    yield fs.pop().result()\n',
        '  File "/usr/local/lib/python3.9/concurrent/futures/_base.py", line 446, in result\n' +
          '    return self.__get_result()\n',
        '  File "/usr/local/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result\n' +
          '    raise self._exception\n',
        '  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 58, in run\n' +
          '    result = self.fn(*self.args, **self.kwargs)\n',
        '  File "/src/services/worker/src/worker/statistics_utils.py", line 672, in get_duration\n' +
          '    return librosa.get_duration(path=f)  # type: ignore   # expects PathLike but BytesIO also works\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/librosa/core/audio.py", line 812, in get_duration\n' +
          '    with audioread.audio_open(path) as fdesc:\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/audioread/__init__.py", line 127, in audio_open\n' +
          '    return BackendClass(path)\n',
        '  File "/src/services/worker/.venv/lib/python3.9/site-packages/audioread/rawread.py", line 59, in __init__\n' +
          "    self._fh = open(filename, 'rb')\n",
        'TypeError: expected str, bytes or os.PathLike object, not BytesIO\n'
      ]
    },

```

Query to identify the affected records:

```
Atlas atlas-x5jgb3-shard-0 [primary] datasets_server_cache> db.cachedResponsesBlue.aggregate([{$match: {error_code: "UnexpectedError", "details.cause_exception":"TypeError", kind:"split-duckdb-index", "details.copied_from_artifact":{$exists:false}}},{$group: {_id: {error: "$details.error"}, count: {$sum: 1}}},{$sort: {count: -1}}])
[
  {
    _id: { error: 'expected str, bytes or os.PathLike object, not BytesIO' },
    count: 3054
  },
...
]
```

If transformed values fail, indexing should continue without fail. It will just not add the transformed columns, but that is not a problem since they won't be visible in the UI either because split-descriptive-statistics fails.