### PR TITLE
fix text and arrow format

### DIFF
--- a/services/worker/src/worker/dtos.py
+++ b/services/worker/src/worker/dtos.py
@@ -313,7 +313,7 @@ class IsValidResponse(TypedDict):
 
 
 DatasetLibrary = Literal["mlcroissant", "webdataset", "datasets", "pandas", "dask"]
-DatasetFormat = Literal["json", "csv", "parquet", "imagefolder", "audiofolder", "webdataset", "text"]
+DatasetFormat = Literal["json", "csv", "parquet", "imagefolder", "audiofolder", "webdataset", "text", "arrow"]
 ProgrammingLanguage = Literal["python"]
 
 

--- a/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
+++ b/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
@@ -634,6 +634,8 @@ get_format_for_builder: dict[str, DatasetFormat] = {
     "parquet": "parquet",
     "imagefolder": "imagefolder",
     "audiofolder": "audiofolder",
+    "text": "text",
+    "arrow": "arrow",
 }
 
 


### PR DESCRIPTION
fix "0 dataset in text format" reported at https://x.com/jedmaczan/status/1809280782588158452

![image](https://github.com/user-attachments/assets/fa328156-7650-4aa2-a828-41d5ab13c37c)

I'll re-launch the job for text datasets