### PR TITLE
move the docs page

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -16,7 +16,7 @@ jobs:
     uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main
     with:
       commit_sha: ${{ github.sha }}
-      package: datasets-server
+      package: dataset-viewer
       notebook_folder: datasets-server_doc
       additional_args: --not_python_module
     secrets:

--- a/.github/workflows/doc-pr-build.yml
+++ b/.github/workflows/doc-pr-build.yml
@@ -18,5 +18,5 @@ jobs:
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}
-      package: datasets-server
+      package: dataset-viewer
       additional_args: --not_python_module

--- a/.github/workflows/doc-pr-upload.yml
+++ b/.github/workflows/doc-pr-upload.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
     with:
-      package_name: datasets-server
+      package_name: dataset-viewer
     secrets:
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}
       comment_bot_token: ${{ secrets.COMMENT_BOT_TOKEN }}

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -66,7 +66,7 @@ For now, there are two libraries
     - [libcommon](./libs/libcommon), which contains the common code for the services and workers.
     - [libapi](./libs/libapi/), which contains common code for authentication, http requests, exceptions and other utilities for the services.
 - [services](./services) contains the applications: 
-    - [api](./services/api/), the public API, is a web server that exposes the [API endpoints](https://huggingface.co/docs/datasets-server). All the responses are served from pre-computed responses in Mongo server. That's the main point of this project: generating these responses takes time, and the API server provides this service to the users.
+    - [api](./services/api/), the public API, is a web server that exposes the [API endpoints](https://huggingface.co/docs/dataset-viewer). All the responses are served from pre-computed responses in Mongo server. That's the main point of this project: generating these responses takes time, and the API server provides this service to the users.
     - [webhook](./services/webhook/), exposes the `/webhook` endpoint which is called by the Hub on every creation, update or deletion of a dataset on the Hub. On deletion, the cached responses   are deleted. On creation or update, a new job is appended in the "queue" database.
     - [rows](./services/rows/)
     - [search](./services/search/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Integrate into your apps over 100,000 datasets via simple HTTP requests, with pre-processed responses and scalability built-in.
 
-Documentation: https://huggingface.co/docs/datasets-server
+Documentation: https://huggingface.co/docs/dataset-viewer
 
 ## Ask for a new feature 🎁
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-BUILD_DIR?=~/tmp/doc-datasets-server
+BUILD_DIR?=~/tmp/doc-dataset-viewer
 POETRY := $(shell command -v poetry@1.8.2 2> /dev/null)
 POETRY_DEFAULT := $(shell command -v poetry 2> /dev/null)
 POETRY := $(if $(POETRY),$(POETRY),$(POETRY_DEFAULT))
@@ -9,8 +9,8 @@ install:
 
 .PHONY: build
 build:
-	$(POETRY) run doc-builder build datasets-server source/ --build_dir $(BUILD_DIR) --not_python_module
+	$(POETRY) run doc-builder build dataset-viewer source/ --build_dir $(BUILD_DIR) --not_python_module
 
 .PHONY: preview
 preview:
-	$(POETRY) run doc-builder preview datasets-server source/ --not_python_module
+	$(POETRY) run doc-builder preview dataset-viewer source/ --not_python_module

--- a/docs/source/croissant.md
+++ b/docs/source/croissant.md
@@ -116,7 +116,7 @@ The endpoint response is a [JSON-LD](https://json-ld.org/) containing the metada
       "@type": "cr:FileSet",
       "@id": "parquet-files-for-config-ParaphraseRC",
       "name": "parquet-files-for-config-ParaphraseRC",
-      "description": "The underlying Parquet files as converted by Hugging Face (see: https://huggingface.co/docs/datasets-server/parquet).",
+      "description": "The underlying Parquet files as converted by Hugging Face (see: https://huggingface.co/docs/dataset-viewer/parquet).",
       "containedIn": {
         "@id": "repo"
       },
@@ -127,7 +127,7 @@ The endpoint response is a [JSON-LD](https://json-ld.org/) containing the metada
       "@type": "cr:FileSet",
       "@id": "parquet-files-for-config-SelfRC",
       "name": "parquet-files-for-config-SelfRC",
-      "description": "The underlying Parquet files as converted by Hugging Face (see: https://huggingface.co/docs/datasets-server/parquet).",
+      "description": "The underlying Parquet files as converted by Hugging Face (see: https://huggingface.co/docs/dataset-viewer/parquet).",
       "containedIn": {
         "@id": "repo"
       },

--- a/docs/source/openapi.json
+++ b/docs/source/openapi.json
@@ -1750,7 +1750,7 @@
         "description": "The list of splits of a dataset.",
         "externalDocs": {
           "description": "See Splits (Hub docs)",
-          "url": "https://huggingface.co/docs/datasets-server/splits"
+          "url": "https://huggingface.co/docs/dataset-viewer/splits"
         },
         "operationId": "listSplits",
         "security": [
@@ -2046,7 +2046,7 @@
         "description": "The list of the 100 first rows of a dataset split.",
         "externalDocs": {
           "description": "See First rows (Hub docs)",
-          "url": "https://huggingface.co/docs/datasets-server/first-rows"
+          "url": "https://huggingface.co/docs/dataset-viewer/first-rows"
         },
         "operationId": "listFirstRows",
         "security": [
@@ -2647,7 +2647,7 @@
         "description": "The list of rows of a dataset split at a given slice location (offset). Up to 100 rows are returned, use the length parameter to get less.",
         "externalDocs": {
           "description": "See rows (Hub docs)",
-          "url": "https://huggingface.co/docs/datasets-server/rows"
+          "url": "https://huggingface.co/docs/dataset-viewer/rows"
         },
         "operationId": "listRows",
         "security": [
@@ -3051,7 +3051,7 @@
         "description": "Returns the rows matching the query, ordered by row index. Up to 100 rows are returned. The offset and length parameters allow to navigate the results.",
         "externalDocs": {
           "description": "See search (Hub docs)",
-          "url": "https://huggingface.co/docs/datasets-server/search"
+          "url": "https://huggingface.co/docs/dataset-viewer/search"
         },
         "operationId": "searchRows",
         "security": [
@@ -3456,7 +3456,7 @@
         "description": "Returns the rows matching the filter query, ordered by row index. Up to 100 rows are returned. The offset and length parameters allow to navigate the results.",
         "externalDocs": {
           "description": "See filter (Hub docs).",
-          "url": "https://huggingface.co/docs/datasets-server/filter"
+          "url": "https://huggingface.co/docs/dataset-viewer/filter"
         },
         "operationId": "filterRows",
         "security": [
@@ -4084,7 +4084,7 @@
         "description": "The dataset is converted to the parquet format. The endpoint gives the list of the parquet files. The same split can have multiple parquet files, called shards. They are sorted by their shard index.",
         "externalDocs": {
           "description": "See Parquet (Hub docs)",
-          "url": "https://huggingface.co/docs/datasets-server/parquet"
+          "url": "https://huggingface.co/docs/dataset-viewer/parquet"
         },
         "operationId": "listParquetFiles",
         "security": [
@@ -4624,7 +4624,7 @@
         "description": "Returns the capabilities of the dataset: show a preview of the 100 first rows, show the viewer for all the rows, search/filter the rows, have statistics. Use the optional config and split parameters to filter the response.",
         "externalDocs": {
           "description": "See Valid datasets (Hub docs)",
-          "url": "https://huggingface.co/docs/datasets-server/valid"
+          "url": "https://huggingface.co/docs/dataset-viewer/valid"
         },
         "operationId": "isValidDataset",
         "security": [
@@ -5069,7 +5069,7 @@
         "description": "Returns the size (number of rows, storage) of the dataset. Use the optional config parameter to filter the response on a subset.",
         "externalDocs": {
           "description": "See size in the Hub docs.",
-          "url": "https://huggingface.co/docs/datasets-server/size"
+          "url": "https://huggingface.co/docs/dataset-viewer/size"
         },
         "operationId": "getSize",
         "security": [
@@ -5320,7 +5320,7 @@
         "description": "Based on the API of spawning.ai, returns the number of image URLs that have been opted-in and opted-out. Use the optional config and split parameters to filter the response. Only a sample of the rows is scanned, the first 100K rows at the moment.",
         "externalDocs": {
           "description": "See spawning.io (Hub docs). The doc is still missing for the endpoint, see https://github.com/huggingface/dataset-viewer/issues/1664.",
-          "url": "https://huggingface.co/docs/datasets-server/"
+          "url": "https://huggingface.co/docs/dataset-viewer/"
         },
         "operationId": "getOptInOutUrls",
         "security": [
@@ -5495,7 +5495,7 @@
         "description": "Based on Presidio, returns the number of rows containing names, emails, phone numbers of sensitive PII. Only a sample of the rows is scanned, the first 10K rows at the moment.",
         "externalDocs": {
           "description": "See https://microsoft.github.io/presidio/. The Hub docs are still missing for the endpoint, see https://github.com/huggingface/dataset-viewer/issues/1664.",
-          "url": "https://huggingface.co/docs/datasets-server/"
+          "url": "https://huggingface.co/docs/dataset-viewer/"
         },
         "operationId": "getPresidioEntities",
         "security": [
@@ -5640,7 +5640,7 @@
         "description": "Returns descriptive statistics, such as min, max, average, histogram, of the columns of a split.",
         "externalDocs": {
           "description": "See statistics (Hub docs).",
-          "url": "https://huggingface.co/docs/datasets-server/statistics"
+          "url": "https://huggingface.co/docs/dataset-viewer/statistics"
         },
         "operationId": "getStatistics",
         "security": [

--- a/jobs/cache_maintenance/src/cache_maintenance/discussions.py
+++ b/jobs/cache_maintenance/src/cache_maintenance/discussions.py
@@ -24,9 +24,9 @@ Apache Parquet is a popular columnar storage format known for:
 - fast data retrieval and filtering,
 - efficient storage.
 
-**This is what powers the dataset viewer** on each dataset page and every dataset on the Hub can be accessed with the same code (you can use HF Datasets, ClickHouse, DuckDB, Pandas or Polars, [up to you](https://huggingface.co/docs/datasets-server/parquet_process)).
+**This is what powers the dataset viewer** on each dataset page and every dataset on the Hub can be accessed with the same code (you can use HF Datasets, ClickHouse, DuckDB, Pandas or Polars, [up to you](https://huggingface.co/docs/dataset-viewer/parquet_process)).
 
-You can learn more about the advantages associated with Parquet in the [documentation](https://huggingface.co/docs/datasets-server/parquet).
+You can learn more about the advantages associated with Parquet in the [documentation](https://huggingface.co/docs/dataset-viewer/parquet).
 
 ## How to access the Parquet version of the dataset?
 
@@ -38,7 +38,7 @@ When the dataset is already in Parquet format, the data are not converted and th
 
 ## What should I do?
 
-You don't need to do anything. The Parquet version of the dataset is available for you to use. Refer to the [documentation](https://huggingface.co/docs/datasets-server/parquet_process) for examples and code snippets on how to query the Parquet files with ClickHouse, DuckDB, Pandas or Polars.
+You don't need to do anything. The Parquet version of the dataset is available for you to use. Refer to the [documentation](https://huggingface.co/docs/dataset-viewer/parquet_process) for examples and code snippets on how to query the Parquet files with ClickHouse, DuckDB, Pandas or Polars.
 
 If you have any questions or concerns, feel free to ask in the discussion below. You can also close the discussion if you don't have any questions."""
 

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -16,14 +16,14 @@ See [../../libs/libcommon/README.md](../../libs/libcommon/README.md) for more in
 
 ## Endpoints
 
-See https://huggingface.co/docs/datasets-server
+See https://huggingface.co/docs/dataset-viewer
 
 - /healthcheck: Ensure the app is running
 - /metrics: Return a list of metrics in the Prometheus format
-- /croissant-crumbs: Return (parts of) the [Croissant](https://huggingface.co/docs/datasets-server/croissant) metadata for a dataset.
-- /is-valid: Tell if a dataset is [valid](https://huggingface.co/docs/datasets-server/valid)
-- /splits: List the [splits](https://huggingface.co/docs/datasets-server/splits) names for a dataset
-- /first-rows: Extract the [first rows](https://huggingface.co/docs/datasets-server/first_rows) for a dataset split
-- /parquet: List the [parquet files](https://huggingface.co/docs/datasets-server/parquet) auto-converted for a dataset
+- /croissant-crumbs: Return (parts of) the [Croissant](https://huggingface.co/docs/dataset-viewer/croissant) metadata for a dataset.
+- /is-valid: Tell if a dataset is [valid](https://huggingface.co/docs/dataset-viewer/valid)
+- /splits: List the [splits](https://huggingface.co/docs/dataset-viewer/splits) names for a dataset
+- /first-rows: Extract the [first rows](https://huggingface.co/docs/dataset-viewer/first_rows) for a dataset split
+- /parquet: List the [parquet files](https://huggingface.co/docs/dataset-viewer/parquet) auto-converted for a dataset
 - /opt-in-out-urls: Return the number of opted-in/out image URLs. See [Spawning AI](https://api.spawning.ai/spawning-api) for more information.
 - /statistics: Return some basic statistics for a dataset split.

--- a/services/rows/README.md
+++ b/services/rows/README.md
@@ -2,7 +2,7 @@
 
 > **GET** /rows
 
-See [usage](https://huggingface.co/docs/datasets-server/rows) for more details.
+See [usage](https://huggingface.co/docs/dataset-viewer/rows) for more details.
 
 ## Configuration
 
@@ -18,7 +18,7 @@ See [../../libs/libcommon/README.md](../../libs/libcommon/README.md) for more in
 
 ## Endpoints
 
-See https://huggingface.co/docs/datasets-server
+See https://huggingface.co/docs/dataset-viewer
 
 - /healthcheck: ensure the app is running
 - /metrics: return a list of metrics in the Prometheus format

--- a/services/search/README.md
+++ b/services/search/README.md
@@ -4,7 +4,7 @@
 >
 > **GET** /filter
 
-See [search](https://huggingface.co/docs/datasets-server/search) and [filter](https://huggingface.co/docs/datasets-server/filter) usage for more details. 
+See [search](https://huggingface.co/docs/dataset-viewer/search) and [filter](https://huggingface.co/docs/dataset-viewer/filter) usage for more details.
 
 ## Configuration
 
@@ -26,7 +26,7 @@ See [../../libs/libcommon/README.md](../../libs/libcommon/README.md) for more in
 
 ## Endpoints
 
-See https://huggingface.co/docs/datasets-server
+See https://huggingface.co/docs/dataset-viewer
 
 - /healthcheck: ensure the app is running
 - /metrics: return a list of metrics in the Prometheus format

--- a/services/webhook/README.md
+++ b/services/webhook/README.md
@@ -14,7 +14,7 @@ See [../../libs/libcommon/README.md](../../libs/libcommon/README.md) for more in
 
 ## Endpoints
 
-See https://huggingface.co/docs/datasets-server
+See https://huggingface.co/docs/dataset-viewer
 
 - /healthcheck: Ensure the app is running
 - /metrics: Return a list of metrics in the Prometheus format

--- a/services/worker/src/worker/job_runners/dataset/croissant_crumbs.py
+++ b/services/worker/src/worker/job_runners/dataset/croissant_crumbs.py
@@ -83,7 +83,7 @@ def get_croissant_crumbs_from_dataset_infos(
                     "@type": "cr:FileSet",
                     "@id": distribution_name,
                     "name": distribution_name,
-                    "description": "The underlying Parquet files as converted by Hugging Face (see: https://huggingface.co/docs/datasets-server/parquet).",
+                    "description": "The underlying Parquet files as converted by Hugging Face (see: https://huggingface.co/docs/dataset-viewer/parquet).",
                     "containedIn": {"@id": repo_name},
                     "encodingFormat": "application/x-parquet",
                     "includes": f"{config}/*/*.parquet",


### PR DESCRIPTION
This change should move https://huggingface.co/docs/datasets-server to https://huggingface.co/docs/dataset-viewer.

cc @mishig25: we also need to redirect https://huggingface.co/docs/datasets-server to https://huggingface.co/docs/dataset-viewer. Where do we do it?