### PR TITLE
Add Polars loading code

### DIFF
--- a/services/worker/src/worker/dtos.py
+++ b/services/worker/src/worker/dtos.py
@@ -312,7 +312,7 @@ class IsValidResponse(TypedDict):
     statistics: bool
 
 
-DatasetLibrary = Literal["mlcroissant", "webdataset", "datasets", "pandas", "dask"]
+DatasetLibrary = Literal["mlcroissant", "webdataset", "datasets", "pandas", "dask", "polars"]
 DatasetFormat = Literal["json", "csv", "parquet", "imagefolder", "audiofolder", "webdataset", "text", "arrow"]
 ProgrammingLanguage = Literal["python"]
 

--- a/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
+++ b/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
@@ -659,30 +659,24 @@ def get_polars_compatible_library(
         dataset: str = dataset,
         login_required: bool = login_required,
     ) -> str:
-        hf_token = ""  # nosec
-
-        if login_required:
-            hf_token = "<your HF token>"  # nosec
-
-        if hf_token:
-            args = f"{args}, storage_options={{'token': '{hf_token}'}}"
-
         if not (args.startswith(", ") or args == ""):
             msg = f"incorrect args format: {args = !s}"
             raise ValueError(msg)
+
+        login_comment = LOGIN_COMMENT if login_required else ""
 
         if len(splits) == 1:
             path = next(iter(splits.values()))
             return f"""\
 import polars as pl
-
+{login_comment}
 df = pl.{read_func}('hf://datasets/{dataset}/{path}'{args})
 """
         else:
             first_split = next(iter(splits))
             return f"""\
 import polars as pl
-
+{login_comment}
 splits = {splits}
 df = pl.{read_func}('hf://datasets/{dataset}/' + splits['{first_split}']{args})
 """

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -136,11 +136,11 @@ EXPECTED_PARQUET = (
                         "arguments": {"splits": {"test": "test.parquet", "train": "train.parquet"}},
                         "code": "import polars as pl\n"
                         "\n"
-                        "splits = {'test': 'test.parquet', 'train': "
-                        "'train.parquet'}\n"
+                        "splits = {'train': 'train.parquet', 'test': "
+                        "'test.parquet'}\n"
                         "df = "
-                        "pl.read_parquet('hf://datasets/nameexhaustion/polars-docs/' "
-                        "+ splits['test'])\n",
+                        "pl.read_parquet('hf://datasets/parquet-dataset/' "
+                        "+ splits['train'])\n",
                         "config_name": "default",
                     }
                 ],
@@ -220,11 +220,11 @@ EXPECTED_PARQUET_LOGIN_REQUIRED = (
                         "arguments": {"splits": {"test": "test.parquet", "train": "train.parquet"}},
                         "code": "import polars as pl\n"
                         "\n"
-                        "splits = {'test': 'test.parquet', 'train': "
-                        "'train.parquet'}\n"
+                        "splits = {'train': 'train.parquet', 'test': "
+                        "'test.parquet'}\n"
                         "df = "
-                        "pl.read_parquet('hf://datasets/nameexhaustion/polars-docs/' "
-                        "+ splits['test'], storage_options={'token': "
+                        "pl.read_parquet('hf://datasets/parquet-dataset-login_required/' "
+                        "+ splits['train'], storage_options={'token': "
                         "'<your HF token>'})\n",
                         "config_name": "default",
                     }

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -220,12 +220,13 @@ EXPECTED_PARQUET_LOGIN_REQUIRED = (
                         "arguments": {"splits": {"test": "test.parquet", "train": "train.parquet"}},
                         "code": "import polars as pl\n"
                         "\n"
+                        "# Login using e.g. `huggingface-cli login` to "
+                        "access this dataset\n"
                         "splits = {'train': 'train.parquet', 'test': "
                         "'test.parquet'}\n"
                         "df = "
                         "pl.read_parquet('hf://datasets/parquet-dataset-login_required/' "
-                        "+ splits['train'], storage_options={'token': "
-                        "'<your HF token>'})\n",
+                        "+ splits['train'])\n",
                         "config_name": "default",
                     }
                 ],

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -127,6 +127,24 @@ EXPECTED_PARQUET = (
                     }
                 ],
             },
+            {
+                "function": "pl.read_parquet",
+                "language": "python",
+                "library": "polars",
+                "loading_codes": [
+                    {
+                        "arguments": {"splits": {"test": "test.parquet", "train": "train.parquet"}},
+                        "code": "import polars as pl\n"
+                        "\n"
+                        "splits = {'test': 'test.parquet', 'train': "
+                        "'train.parquet'}\n"
+                        "df = "
+                        "pl.read_parquet('hf://datasets/nameexhaustion/polars-docs/' "
+                        "+ splits['test'])\n",
+                        "config_name": "default",
+                    }
+                ],
+            },
         ],
     },
     1.0,
@@ -190,6 +208,25 @@ EXPECTED_PARQUET_LOGIN_REQUIRED = (
                             "ds = Dataset(jsonld=jsonld)\n"
                             'records = ds.records("default")'
                         ),
+                    }
+                ],
+            },
+            {
+                "function": "pl.read_parquet",
+                "language": "python",
+                "library": "polars",
+                "loading_codes": [
+                    {
+                        "arguments": {"splits": {"test": "test.parquet", "train": "train.parquet"}},
+                        "code": "import polars as pl\n"
+                        "\n"
+                        "splits = {'test': 'test.parquet', 'train': "
+                        "'train.parquet'}\n"
+                        "df = "
+                        "pl.read_parquet('hf://datasets/nameexhaustion/polars-docs/' "
+                        "+ splits['test'], storage_options={'token': "
+                        "'<your HF token>'})\n",
+                        "config_name": "default",
                     }
                 ],
             },


### PR DESCRIPTION
Hello from the Polars team! We've recently added support for scanning Hugging Face datasets, and to make it easier for users we're hoping that Polars code snippets could be added under the "Use this dataset" section on the dataset viewer webpage, next to the other libraries.

Specifically, here's where we'd like to add Polars as an option:
<img width="247" alt="image" src="https://github.com/user-attachments/assets/53868c96-7e70-4489-a785-2e4287a69f52">

