### PR TITLE
fix 'FileNotFoundError' in polars detection function

### DIFF
--- a/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
+++ b/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
@@ -697,6 +697,9 @@ df = pl.{read_func}('hf://datasets/{dataset}/' + splits['{first_split}']{args})
 
     elif builder_name == "json":
         first_file = f"datasets/{dataset}/" + next(iter(loading_codes[0]["arguments"]["splits"].values()))
+        if "*" in first_file:
+            # The pattern 'datasets/[dataset]/**/*' is not supported yet
+            return None
         is_json_lines = ".jsonl" in first_file or HfFileSystem(token=hf_token).open(first_file, "r").read(1) != "["
 
         if is_json_lines:

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -20,6 +20,7 @@ from worker.job_runners.dataset.compatible_libraries import (
     DatasetCompatibleLibrariesJobRunner,
     get_builder_configs_with_simplified_data_files,
     get_compatible_library_for_builder,
+    get_polars_compatible_library,
 )
 from worker.resources import LibrariesResource
 
@@ -546,3 +547,19 @@ def test_get_builder_configs_with_simplified_data_files(
     assert module_name in get_compatible_library_for_builder
     compatible_library = get_compatible_library_for_builder[module_name](dataset, hf_token, login_required)
     assert compatible_library["library"] == expected_library
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "dataset,builder_name",
+    [
+        ("tcor0005/langchain-docs-400-chunksize", "json"),
+    ],
+)
+def test_get_polars_compatible_library(
+    use_hub_prod_endpoint: pytest.MonkeyPatch,
+    dataset: str,
+    builder_name: str,
+) -> None:
+    v = get_polars_compatible_library(builder_name=builder_name, dataset=dataset, hf_token=None, login_required=False)
+    assert v is None


### PR DESCRIPTION
We simply don't put Polars as a supported library when we're not able to detect if it's JSON or JSONL.

TODO: transform `**/*` to a list of files? In the case of `datasets/tcor0005/langchain-docs-400-chunksize`, it's a single file

---

The error we fix:

```
tests/job_runners/dataset/test_compatible_libraries.py:564:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/worker/job_runners/dataset/compatible_libraries.py:700: in get_polars_compatible_library
    is_json_lines = ".jsonl" in first_file or HfFileSystem(token=hf_token).open(first_file, "r").read(1) != "["
.venv/lib/python3.9/site-packages/fsspec/spec.py:1281: in open
    self.open(
.venv/lib/python3.9/site-packages/fsspec/spec.py:1293: in open
    f = self._open(
.venv/lib/python3.9/site-packages/huggingface_hub/hf_file_system.py:236: in _open
    return HfFileSystemFile(self, path, mode=mode, revision=revision, block_size=block_size, **kwargs)
.venv/lib/python3.9/site-packages/huggingface_hub/hf_file_system.py:687: in __init__
    self.details = fs.info(self.resolved_path.unresolve(), expand_info=False)
.venv/lib/python3.9/site-packages/huggingface_hub/hf_file_system.py:520: in info
    self.ls(parent_path, expand_info=False)
.venv/lib/python3.9/site-packages/huggingface_hub/hf_file_system.py:294: in ls
    _raise_file_not_found(path, None)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

path = 'datasets/tcor0005/langchain-docs-400-chunksize/**', err = None

    def _raise_file_not_found(path: str, err: Optional[Exception]) -> NoReturn:
        msg = path
        if isinstance(err, RepositoryNotFoundError):
            msg = f"{path} (repository not found)"
        elif isinstance(err, RevisionNotFoundError):
            msg = f"{path} (revision not found)"
        elif isinstance(err, HFValidationError):
            msg = f"{path} (invalid repository id)"
>       raise FileNotFoundError(msg) from err
E       FileNotFoundError: datasets/tcor0005/langchain-docs-400-chunksize/**

.venv/lib/python3.9/site-packages/huggingface_hub/hf_file_system.py:868: FileNotFoundError
```