### PR TITLE
add a field to the index + it should fix the deployment issue

### DIFF
--- a/libs/libcommon/src/libcommon/queue/metrics.py
+++ b/libs/libcommon/src/libcommon/queue/metrics.py
@@ -67,7 +67,7 @@ class JobTotalMetricDocument(Document):
     meta = {
         "collection": TYPE_STATUS_AND_DATASET_STATUS_JOB_COUNTS_COLLECTION,
         "db_alias": QUEUE_MONGOENGINE_ALIAS,
-        "indexes": [("job_type", "status")],
+        "indexes": [("job_type", "status", "dataset_status")],
     }
     objects = QuerySetManager["JobTotalMetricDocument"]()
 


### PR DESCRIPTION
deployment (migration script) error:

```
INFO: 2024-07-31 22:33:14,880 - root - Start migrations
INFO: 2024-07-31 22:33:14,926 - root - 72 migrations have already been applied. They will be skipped.
INFO: 2024-07-31 22:33:14,927 - root - Migrate 20240731143600: add to the migrations collection
INFO: 2024-07-31 22:33:14,931 - root - Migrate 20240731143600: apply
INFO: 2024-07-31 22:33:14,931 - root - If missing, add the 'dataset_status' field with the default value 'normal' to the jobs metrics
INFO: 2024-07-31 22:33:14,941 - root - Migrate 20240731143600: validate
INFO: 2024-07-31 22:33:14,941 - root - Ensure that a random selection of jobs metrics have the 'dataset_status' field
ERROR: 2024-07-31 22:33:14,943 - root - Migration failed: An existing index has the same name as the requested index. When index names are not specified, they are auto generated and can cause conflicts. Please refer to our documentation. Requested index: { v: 2, key: { job_type: 1, status: 1 }, name: "job_type_1_status_1", background: false }, existing index: { v: 2, unique: true, key: { job_type: 1, status: 1 }, name: "job_type_1_status_1", background: false, sparse: false }, full error: {'ok': 0.0, 'errmsg': 'An existing index has the same name as the requested index. When index names are not specified, they are auto generated and can cause conflicts. Please refer to our documentation. Requested index: { v: 2, key: { job_type: 1, status: 1 }, name: "job_type_1_status_1", background: false }, existing index: { v: 2, unique: true, key: { job_type: 1, status: 1 }, name: "job_type_1_status_1", background: false, sparse: false }', 'code': 86, 'codeName': 'IndexKeySpecsConflict', '$clusterTime': {'clusterTime': Timestamp(1722465194, 566), 'signature': {'hash': b'\xa0C\xe2\xd5;Z\xfd:8\x8d\xfe\x0fX\x1a\xbd\x87\x94D\xe3\xd4', 'keyId': 7345684769667022921}}, 'operationTime': Timestamp(1722465194, 566)}
INFO: 2024-07-31 22:33:14,943 - root - Start rollback
INFO: 2024-07-31 22:33:14,943 - root - Rollback 20240731143600: roll back
INFO: 2024-07-31 22:33:14,943 - root - Remove the 'dataset_status' field from all the jobs metrics
INFO: 2024-07-31 22:33:14,952 - root - Rollback 20240731143600: removed from the migrations collection
INFO: 2024-07-31 22:33:14,956 - root - Rollback 20240731143600: done
INFO: 2024-07-31 22:33:14,956 - root - All executed migrations have been rolled back
ERROR: 2024-07-31 22:33:14,959 - root - An existing index has the same name as the requested index. When index names are not specified, they are auto generated and can cause conflicts. Please refer to our documentation. Requested index: { v: 2, key: { job_type: 1, status: 1 }, name: "job_type_1_status_1", background: false }, existing index: { v: 2, unique: true, key: { job_type: 1, status: 1 }, name: "job_type_1_status_1", background: false, sparse: false }, full error: {'ok': 0.0, 'errmsg': 'An existing index has the same name as the requested index. When index names are not specified, they are auto generated and can cause conflicts. Please refer to our documentation. Requested index: { v: 2, key: { job_type: 1, status: 1 }, name: "job_type_1_status_1", background: false }, existing index: { v: 2, unique: true, key: { job_type: 1, status: 1 }, name: "job_type_1_status_1", background: false, sparse: false }', 'code': 86, 'codeName': 'IndexKeySpecsConflict', '$clusterTime': {'clusterTime': Timestamp(1722465194, 566), 'signature': {'hash': b'\xa0C\xe2\xd5;Z\xfd:8\x8d\xfe\x0fX\x1a\xbd\x87\x94D\xe3\xd4', 'keyId': 7345684769667022921}}, 'operationTime': Timestamp(1722465194, 566)}
```