### PR TITLE
Re-enable Polars as a supported library for jsonl with glob paths

### DIFF
--- a/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
+++ b/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
@@ -697,15 +697,13 @@ df = pl.{read_func}('hf://datasets/{dataset}/' + splits['{first_split}']{args})
 
     elif builder_name == "json":
         first_file = f"datasets/{dataset}/" + next(iter(loading_codes[0]["arguments"]["splits"].values()))
-        if "*" in first_file:
-            # The pattern 'datasets/[dataset]/**/*' is not supported yet
-            return None
         is_json_lines = ".jsonl" in first_file or HfFileSystem(token=hf_token).open(first_file, "r").read(1) != "["
 
         if is_json_lines:
             read_func = "read_ndjson"
         else:
-            read_func = "read_json"
+            # JSON not yet supported by Polars
+            return None
 
         compatible_library["function"] = f"pl.{read_func}"
     else:

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -547,19 +547,3 @@ def test_get_builder_configs_with_simplified_data_files(
     assert module_name in get_compatible_library_for_builder
     compatible_library = get_compatible_library_for_builder[module_name](dataset, hf_token, login_required)
     assert compatible_library["library"] == expected_library
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize(
-    "dataset,builder_name",
-    [
-        ("tcor0005/langchain-docs-400-chunksize", "json"),
-    ],
-)
-def test_get_polars_compatible_library(
-    use_hub_prod_endpoint: pytest.MonkeyPatch,
-    dataset: str,
-    builder_name: str,
-) -> None:
-    v = get_polars_compatible_library(builder_name=builder_name, dataset=dataset, hf_token=None, login_required=False)
-    assert v is None


### PR DESCRIPTION
Ref https://github.com/huggingface/dataset-viewer/pull/3006
Issue fixed by https://github.com/pola-rs/polars/pull/17958
