### PR TITLE
Fix CI test StorageClient.url_preparator

### DIFF
--- a/libs/libapi/tests/test_response.py
+++ b/libs/libapi/tests/test_response.py
@@ -8,6 +8,7 @@ from datasets import Dataset, Image
 from datasets.table import embed_table_storage
 from libcommon.constants import ROW_IDX_COLUMN
 from libcommon.storage_client import StorageClient
+from libcommon.url_preparator import URLPreparator
 from PIL import Image as PILImage
 
 from libapi.response import create_response
@@ -23,6 +24,7 @@ def storage_client(tmp_path: Path) -> StorageClient:
         protocol="file",
         storage_root=str(tmp_path / CACHED_ASSETS_FOLDER),
         base_url="http://localhost/cached-assets",
+        url_preparator=URLPreparator(url_signer=None),
     )
 
 


### PR DESCRIPTION
Fix CI test StorageClient.url_preparator.

This fail in CI tests was introduced after:
- #2966

See: https://github.com/huggingface/dataset-viewer/actions/runs/10350752694/job/28648303009?pr=3018
```
FAILED tests/test_response.py::test_create_response_with_image - AssertionError: assert [{'row': {'im...d_cells': []}] == [{'row': {'im...d_cells': []}]
  
  At index 0 diff: {'row_idx': 0, 'row': {'image': {'src': 'http://localhost/cached-assets/ds_image/--/{dataset_git_revision}/--/default/train/0/image/image.jpg', 'height': 480, 'width': 640}}, 'truncated_cells': []} != {'row_idx': 0, 'row': {'image': {'src': 'http://localhost/cached-assets/ds_image/--/revision/--/default/train/0/image/image.jpg', 'height': 480, 'width': 640}}, 'truncated_cells': []}
  
  Full diff:
    [
        {
            'row': {
                'image': {
                    'height': 480,
  -                 'src': 'http://localhost/cached-assets/ds_image/--/revision/--/default/train/0/image/image.jpg',
  +                 'src': 'http://localhost/cached-assets/ds_image/--/{dataset_git_revision}/--/default/train/0/image/image.jpg',
  ?                                                                    +++++++++++++        +
                    'width': 640,
                },
            },
            'row_idx': 0,
            'truncated_cells': [],
        },
    ]
```