### PR TITLE
Fix CI e2e admin test_metrics with missing dataset_status

### DIFF
--- a/e2e/tests/test_21_api_metrics.py
+++ b/e2e/tests/test_21_api_metrics.py
@@ -31,7 +31,7 @@ def test_metrics() -> None:
         # these metrics are only available in the admin API
         assert not has_metric(
             name="queue_jobs_total",
-            labels={"pid": "[0-9]*", "queue": endpoint, "status": "started"},
+            labels={"dataset_status": "normal", "pid": "[0-9]*", "queue": endpoint, "status": "started"},
             metric_names=metric_names,
         ), f"queue_jobs_total - endpoint={endpoint} found in {metrics}"
         assert not has_metric(

--- a/e2e/tests/test_31_admin_metrics.py
+++ b/e2e/tests/test_31_admin_metrics.py
@@ -25,7 +25,7 @@ def test_metrics() -> None:
     metric_names = set(metrics.keys())
 
     # the queue metrics are computed each time a job is created and processed
-    # they should exists at least for some of jobs types
+    # they should exist at least for some of jobs types
     for queue in ["dataset-config-names", "split-first-rows", "dataset-parquet"]:
         # eg. 'queue_jobs_total{pid="10",queue="split-first-rows",status="started"}'
         assert has_metric(
@@ -35,7 +35,7 @@ def test_metrics() -> None:
         ), f"queue_jobs_total - queue={queue} found in {metrics}"
 
     # the queue metrics are computed each time a job is created and processed
-    # they should exists at least for some of jobs types
+    # they should exist at least for some of jobs types
     for worker_size in [
         "light",
         "medium",
@@ -48,7 +48,7 @@ def test_metrics() -> None:
         ), f"worker_size_jobs_count - worker_size={worker_size} found in {metrics}"
 
     # the cache metrics are computed each time a job is processed
-    # they should exists at least for some of cache kinds
+    # they should exist at least for some of cache kinds
     for cache_kind in ["dataset-config-names", "split-first-rows", "dataset-parquet"]:
         # cache should have been filled by the previous tests
         # eg. 'responses_in_cache_total{error_code="None",http_status="200",path="dataset-config-names",pid="10"}'

--- a/e2e/tests/test_31_admin_metrics.py
+++ b/e2e/tests/test_31_admin_metrics.py
@@ -30,7 +30,7 @@ def test_metrics() -> None:
         # eg. 'queue_jobs_total{pid="10",queue="split-first-rows",status="started"}'
         assert has_metric(
             name="queue_jobs_total",
-            labels={"pid": "[0-9]*", "queue": queue, "status": "started"},
+            labels={"dataset_status": "normal", "pid": "[0-9]*", "queue": queue, "status": "started"},
             metric_names=metric_names,
         ), f"queue_jobs_total - queue={queue} found in {metrics}"
 

--- a/e2e/tests/test_41_rows_metrics.py
+++ b/e2e/tests/test_41_rows_metrics.py
@@ -31,7 +31,7 @@ def test_metrics() -> None:
         # these metrics are only available in the admin API
         assert not has_metric(
             name="queue_jobs_total",
-            labels={"pid": "[0-9]*", "queue": endpoint, "status": "started"},
+            labels={"dataset_status": "normal", "pid": "[0-9]*", "queue": endpoint, "status": "started"},
             metric_names=metric_names,
         ), f"queue_jobs_total - endpoint={endpoint} found in {metrics}"
         assert not has_metric(

--- a/e2e/tests/test_51_search_metrics.py
+++ b/e2e/tests/test_51_search_metrics.py
@@ -31,7 +31,7 @@ def test_metrics() -> None:
         # these metrics are only available in the admin API
         assert not has_metric(
             name="queue_jobs_total",
-            labels={"pid": "[0-9]*", "queue": endpoint, "status": "started"},
+            labels={"dataset_status": "normal", "pid": "[0-9]*", "queue": endpoint, "status": "started"},
             metric_names=metric_names,
         ), f"queue_jobs_total - endpoint={endpoint} found in {metrics}"
         assert not has_metric(


### PR DESCRIPTION
Fix CI e2e admin test_metrics by adding missing `dataset_status="normal"` label.

This CI failure was introduced by:
- #3008

Fix #3021.