### PR TITLE
Fix CI worker tests for gated datasets

### DIFF
--- a/services/worker/tests/job_runners/config/test_split_names.py
+++ b/services/worker/tests/job_runners/config/test_split_names.py
@@ -173,7 +173,7 @@ def test_doesnotexist(
         # should we really test the following cases?
         # The assumption is that the dataset exists and is accessible with the token
         ("does_not_exist", False, "SplitNamesFromStreamingError", "DatasetNotFoundError"),
-        ("gated", False, "SplitNamesFromStreamingError", "ConnectionError"),  # See: huggingface/huggingface_hub#2457
+        ("gated", False, "SplitNamesFromStreamingError", "ConnectionError"),  # See: huggingface/datasets#7109
         ("private", False, "SplitNamesFromStreamingError", "DatasetNotFoundError"),
     ],
 )

--- a/services/worker/tests/job_runners/config/test_split_names.py
+++ b/services/worker/tests/job_runners/config/test_split_names.py
@@ -173,7 +173,7 @@ def test_doesnotexist(
         # should we really test the following cases?
         # The assumption is that the dataset exists and is accessible with the token
         ("does_not_exist", False, "SplitNamesFromStreamingError", "DatasetNotFoundError"),
-        ("gated", False, "SplitNamesFromStreamingError", "DatasetNotFoundError"),
+        ("gated", False, "SplitNamesFromStreamingError", "ConnectionError"),  # See: huggingface/huggingface_hub#2457
         ("private", False, "SplitNamesFromStreamingError", "DatasetNotFoundError"),
     ],
 )

--- a/services/worker/tests/job_runners/dataset/test_config_names.py
+++ b/services/worker/tests/job_runners/dataset/test_config_names.py
@@ -99,7 +99,7 @@ def test_compute_too_many_configs(
         # should we really test the following cases?
         # The assumption is that the dataset exists and is accessible with the token
         ("does_not_exist", False, "ConfigNamesError", "DatasetNotFoundError"),
-        ("gated", False, "ConfigNamesError", "ConnectionError"),  # See: huggingface/huggingface_hub#2457
+        ("gated", False, "ConfigNamesError", "ConnectionError"),  # See: huggingface/datasets#7109
         ("private", False, "ConfigNamesError", "DatasetNotFoundError"),
     ],
 )

--- a/services/worker/tests/job_runners/dataset/test_config_names.py
+++ b/services/worker/tests/job_runners/dataset/test_config_names.py
@@ -99,7 +99,7 @@ def test_compute_too_many_configs(
         # should we really test the following cases?
         # The assumption is that the dataset exists and is accessible with the token
         ("does_not_exist", False, "ConfigNamesError", "DatasetNotFoundError"),
-        ("gated", False, "ConfigNamesError", "DatasetNotFoundError"),
+        ("gated", False, "ConfigNamesError", "ConnectionError"),  # See: huggingface/huggingface_hub#2457
         ("private", False, "ConfigNamesError", "DatasetNotFoundError"),
     ],
 )


### PR DESCRIPTION
Fix CI worker tests for gated datasets.

Fix #3025.