### PR TITLE
mediatype of opus is audio/ogg

### DIFF
--- a/libs/libcommon/src/libcommon/viewer_utils/asset.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/asset.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from libcommon.storage_client import StorageClient
 
 
-SUPPORTED_AUDIO_EXTENSION_TO_MEDIA_TYPE = {".wav": "audio/wav", ".mp3": "audio/mpeg", ".opus": "audio/opus"}
+SUPPORTED_AUDIO_EXTENSION_TO_MEDIA_TYPE = {".wav": "audio/wav", ".mp3": "audio/mpeg", ".opus": "audio/ogg"}
 SUPPORTED_AUDIO_EXTENSIONS = SUPPORTED_AUDIO_EXTENSION_TO_MEDIA_TYPE.keys()
 DATASET_GIT_REVISION_PLACEHOLDER = "{dataset_git_revision}"
 


### PR DESCRIPTION
I had set it to `audio/opus` which does not exist.

https://datatracker.ietf.org/doc/html/rfc7845.html#section-9

> An "Ogg Opus file" consists of one or more sequentially multiplexed
   segments, each containing exactly one Ogg Opus stream.  The
   RECOMMENDED mime-type for Ogg Opus files is "audio/ogg".

>    The RECOMMENDED filename extension for Ogg Opus files is '.opus'.

> When Opus is concurrently multiplexed with other streams in an Ogg
   container, one SHOULD use one of the "audio/ogg", "video/ogg", or
   "application/ogg" mime-types, as defined in [[RFC5334](https://datatracker.ietf.org/doc/html/rfc5334)].


https://github.com/user-attachments/assets/caed4ee5-975d-4233-9cf8-31fd755b2429

