### PR TITLE
return 404 when accessing a renamed dataset, instead of unexpected error

### DIFF
--- a/libs/libapi/src/libapi/authentication.py
+++ b/libs/libapi/src/libapi/authentication.py
@@ -13,6 +13,7 @@ from libapi.exceptions import (
     AuthCheckHubRequestError,
     ExternalAuthenticatedError,
     ExternalUnauthenticatedError,
+    RenamedDatasetError,
 )
 from libapi.jwt_token import validate_jwt
 
@@ -115,6 +116,8 @@ async def auth_check(
     with StepProfiler(method="auth_check", step="return or raise"):
         if response.status_code == 200:
             return True
+        elif response.status_code == 307:
+            raise RenamedDatasetError("The dataset has been renamed. Please use the current dataset name.")
         elif response.status_code == 401:
             raise ExternalUnauthenticatedError(
                 "The dataset does not exist, or is not accessible without authentication (private or gated). Please"

--- a/libs/libapi/src/libapi/exceptions.py
+++ b/libs/libapi/src/libapi/exceptions.py
@@ -22,6 +22,7 @@ ApiErrorCode = Literal[
     "JWTMissingRequiredClaim",
     "MissingProcessingStepsError",
     "MissingRequiredParameter",
+    "RenamedDatasetError",
     "ResponseNotFound",
     "ResponseNotReady",
     "SearchFeatureNotAvailableError",
@@ -111,6 +112,13 @@ class ResponseNotFoundError(ApiError):
 
     def __init__(self, message: str):
         super().__init__(message, HTTPStatus.NOT_FOUND, "ResponseNotFound")
+
+
+class RenamedDatasetError(ApiError):
+    """The dataset had been renamed. The current name is not found."""
+
+    def __init__(self, message: str):
+        super().__init__(message, HTTPStatus.NOT_FOUND, "RenamedDatasetError")
 
 
 class ResponseNotReadyError(ApiError):


### PR DESCRIPTION
fixes bug at https://github.com/huggingface/dataset-viewer/issues/2688#issuecomment-2303305529
