### PR TITLE
Increase executor time out for staging

### DIFF
--- a/services/worker/src/worker/executor.py
+++ b/services/worker/src/worker/executor.py
@@ -73,7 +73,7 @@ class WorkerExecutor:
             START_WORKER_LOOP_PATH,
             "--print-worker-state-path",
         ]
-        return OutputExecutor(start_worker_loop_command, banner, timeout=10)
+        return OutputExecutor(start_worker_loop_command, banner, timeout=20)
 
     def _create_web_app_executor(self) -> TCPExecutor:
         logging.info("Starting webapp for /healthcheck and /metrics.")
@@ -87,7 +87,7 @@ class WorkerExecutor:
         self.executors.append(worker_loop_executor)
 
         web_app_executor = self._create_web_app_executor()
-        web_app_executor.start()  # blocking until the banner is printed
+        web_app_executor.start()  # blocking until socket connection is established
         self.executors.append(web_app_executor)
 
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
workers i nstaging env don't start because of that

```
DEBUG: 2024-10-29 17:29:31,793 - mirakuru.base - Starting process: ['/src/services/worker/.venv/bin/python', '/src/services/worker/src/worker/start_worker_loop.py', '--print-worker-state-path']
Traceback (most recent call last):
  File "/src/services/worker/src/worker/main.py", line 76, in <module>
    worker_executor.start()
  File "/src/services/worker/src/worker/executor.py", line 86, in start
    worker_loop_executor.start()  # blocking until the banner is printed
  File "/src/services/worker/.venv/lib/python3.9/site-packages/mirakuru/output.py", line 105, in start
    self.wait_for(await_for_output)
  File "/src/services/worker/.venv/lib/python3.9/site-packages/mirakuru/base.py", line 450, in wait_for
    raise TimeoutExpired(self, timeout=self._timeout)
mirakuru.exceptions.TimeoutExpired: Executor <mirakuru.output.OutputExecutor: "/src/services/worker/.venv/bin/python /src/services/worker/src/worker/start_worker_loop.py --print-worker-state-path" 0x7fde123b7a30> timed out after 10 seconds
DEBUG: 2024-10-29 17:29:41,920 - asyncio - Using selector: EpollSelector
```

this makes it hard to differentiate a slow start from a crash