### PR TITLE
Add foursquare/fsq-os-places truncated binary support

### DIFF
--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -96,7 +96,7 @@ def create_rows_endpoint(
                     with StepProfiler(method="rows_endpoint", step="query the rows"):
                         try:
                             truncated_columns: list[str] = []
-                            if dataset == "Major-TOM/Core-S2L2A":
+                            if dataset == "Major-TOM/Core-S2L2A" or dataset == "foursquare/fsq-os-places":
                                 pa_table, truncated_columns = rows_index.query_truncated_binary(
                                     offset=offset, length=length
                                 )


### PR DESCRIPTION
Right now pagination doesn't work because of `cast_table_to_features()` here:

https://github.com/huggingface/datasets-server/blob/1091250943b90de3b27895b03c711891b95e6309/services/rows/src/rows/routes/rows.py#L105

indeed the table doesn't contain the binary data "geom" (unsupported column) while the features have this column.

In this PR I apply the logic from https://github.com/huggingface/dataset-viewer/pull/2543 which adds a better support for binary data by truncating them if necessary and when possible instead of just not showing them.