### PR TITLE
Fix excluded binary column in rows

### DIFF
--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -97,7 +97,7 @@ def create_rows_endpoint(
                     with StepProfiler(method="rows_endpoint", step="query the rows"):
                         try:
                             truncated_columns: list[str] = []
-                            if dataset == "Major-TOM/Core-S2L2A":
+                            if dataset == "Major-TOM/Core-S2L2A" or dataset == "foursquare/fsq-os-places":
                                 pa_table, truncated_columns = rows_index.query_truncated_binary(
                                     offset=offset, length=length
                                 )

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -103,7 +103,9 @@ def create_rows_endpoint(
                                 )
                             else:
                                 pa_table = rows_index.query(offset=offset, length=length)
-                            features = Features({col: rows_index.parquet_index.features[col] for col in pa_table.column_names})
+                            features = Features(
+                                {col: rows_index.parquet_index.features[col] for col in pa_table.column_names}
+                            )
                             pa_table = cast_table_to_features(pa_table, features)
                         except TooBigRows as err:
                             raise TooBigContentError(str(err)) from None

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -4,6 +4,7 @@
 import logging
 from typing import Literal, Optional, Union
 
+from datasets import Features
 from datasets.table import cast_table_to_features
 from fsspec.implementations.http import HTTPFileSystem
 from libapi.authentication import auth_check
@@ -102,7 +103,8 @@ def create_rows_endpoint(
                                 )
                             else:
                                 pa_table = rows_index.query(offset=offset, length=length)
-                            pa_table = cast_table_to_features(pa_table, rows_index.parquet_index.features)
+                            features = Features({col: rows_index.parquet_index.features[col] for col in pa_table.column_names})
+                            pa_table = cast_table_to_features(pa_table, features)
                         except TooBigRows as err:
                             raise TooBigContentError(str(err)) from None
                     with StepProfiler(method="rows_endpoint", step="transform to a list"):


### PR DESCRIPTION
Fix pagination for https://huggingface.co/datasets/foursquare/fsq-os-places and https://huggingface.co/datasets/Major-TOM/Core-S2L2A which have binary columns. Currently it raises an UnexpectedApiError