### PR TITLE
higher timeout

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -277,7 +277,7 @@ admin:
   # Number of reports in /cache-reports-with-content/... endpoints
   cacheReportsWithContentNumResults: 100
   # the timeout in seconds for the requests to the Hugging Face Hub.
-  hfTimeoutSeconds: "1.5"
+  hfTimeoutSeconds: "10"
   # Number of uvicorn workers for running the application
   # (2 x $num_cores) + 1
   # https://docs.gunicorn.org/en/stable/design.html#how-many-workers


### PR DESCRIPTION
was causing timeout on get_latest_dataset_revision_if_supported_or_raise preventing jobs from being added to the queue after dataset-config-names