### PR TITLE
Log incoherent state error

### DIFF
--- a/libs/libcommon/src/libcommon/operations.py
+++ b/libs/libcommon/src/libcommon/operations.py
@@ -317,9 +317,10 @@ def backfill_dataset(
         return delete_dataset(dataset=dataset, storage_clients=storage_clients)
     try:
         tasks_statistics = backfill(dataset=dataset, revision=revision, priority=priority)
-    except IncoherentCacheError:
+    except IncoherentCacheError as e:
         logging.warning(
-            f"Dataset {dataset} has incoherent entries in the cache. Let's first delete the dataset, then backfill again."
+            f"Dataset {dataset} has incoherent entries in the cache. Let's first delete the dataset, then backfill again. "
+            f"{type(e).__name__}: {e}"
         )
         delete_dataset(dataset=dataset, storage_clients=storage_clients)
         tasks_statistics = backfill(dataset=dataset, revision=revision, priority=priority)


### PR DESCRIPTION
I got this which triggered a recompute of the dataset but I don't know why it happened, adding some logs in case it happens again

> WARNING: 2024-12-10 10:35:59,554 - root - Dataset HuggingFaceFW/fineweb-2 has incoherent entries in the cache. Let's first delete the dataset, then backfill again.