### PR TITLE
Fix backfill deleting cache when split names not ready

### DIFF
--- a/libs/libcommon/src/libcommon/state.py
+++ b/libs/libcommon/src/libcommon/state.py
@@ -232,13 +232,14 @@ class ConfigState:
                 name_field="split",
             )  # Note that we use the cached content even the revision is different (ie. maybe obsolete)
 
-        unexpected_split_names = set(cache_entries_df["split"].unique()).difference(
-            set(self.split_names).union({None})
-        )
-        if unexpected_split_names:
-            raise UnexceptedSplitNamesError(
-                f"Unexpected split names for dataset={self.dataset} config={self.config} ({len(unexpected_split_names)}): {list(islice(unexpected_split_names, 10))}{'' if len(unexpected_split_names) <= 10 else '...'}"
+        if self.split_names:  # emoty if the config-split-names cache is missing
+            unexpected_split_names = set(cache_entries_df["split"].unique()).difference(
+                set(self.split_names).union({None})
             )
+            if unexpected_split_names:
+                raise UnexceptedSplitNamesError(
+                    f"Unexpected split names for dataset={self.dataset} config={self.config} ({len(unexpected_split_names)}): {list(islice(unexpected_split_names, 10))}{'' if len(unexpected_split_names) <= 10 else '...'}"
+                )
 
         with StepProfiler(
             method="ConfigState.__post_init__",

--- a/libs/libcommon/src/libcommon/state.py
+++ b/libs/libcommon/src/libcommon/state.py
@@ -232,7 +232,7 @@ class ConfigState:
                 name_field="split",
             )  # Note that we use the cached content even the revision is different (ie. maybe obsolete)
 
-        if self.split_names:  # emoty if the config-split-names cache is missing
+        if self.split_names:  # empty if the config-split-names cache is missing
             unexpected_split_names = set(cache_entries_df["split"].unique()).difference(
                 set(self.split_names).union({None})
             )


### PR DESCRIPTION
Fix issues like

> WARNING: 2024-12-13 10:18:31,382 - root - Dataset HuggingFaceFW/fineweb-2 has incoherent entries in the cache. Let's first delete the dataset, then backfill again. UnexceptedSplitNamesError: Unexpected split names for dataset=HuggingFaceFW/fineweb-2 config=mor_Latn (1): ['train']

it happended because at the time of the backfill:
- config-split-names wasn't ready yet for `config=mor_Latn`
- split-first-rows was ready for `config=mor_Latn` and `split=train` (possible since the job if triggered by both config-split-names and config-parquet-metadata which enables reading from parquet to get the first rows)