### PR TITLE
Fix missing parquet columns

### DIFF
--- a/libs/libcommon/src/libcommon/parquet_utils.py
+++ b/libs/libcommon/src/libcommon/parquet_utils.py
@@ -13,6 +13,7 @@ import pyarrow.compute as pc
 import pyarrow.parquet as pq
 from datasets import Features, Value
 from datasets.features.features import FeatureType
+from datasets.table import cast_table_to_schema
 from datasets.utils.py_utils import size_str
 from fsspec.implementations.http import HTTPFile, HTTPFileSystem
 from huggingface_hub import HfFileSystem
@@ -146,7 +147,9 @@ class RowGroupReader:
     features: Features
 
     def read(self, columns: list[str]) -> pa.Table:
-        return self.parquet_file.read_row_group(i=self.group_id, columns=columns)
+        pa_table = self.parquet_file.read_row_group(i=self.group_id, columns=columns)
+        # cast_table_to_schema adds null values to missing columns
+        return cast_table_to_schema(pa_table, self.features.arrow_schema)
 
     def read_truncated_binary(self, columns: list[str], max_binary_length: int) -> tuple[pa.Table, list[str]]:
         pa_table = self.parquet_file.read_row_group(i=self.group_id, columns=columns)
@@ -157,7 +160,7 @@ class RowGroupReader:
                     truncated_array = pc.binary_slice(pa_table[field_idx], 0, max_binary_length // len(pa_table))
                     pa_table = pa_table.set_column(field_idx, field, truncated_array)
                     truncated_columns.append(field.name)
-        return pa_table, truncated_columns
+        return cast_table_to_schema(pa_table, self.features.arrow_schema), truncated_columns
 
     def read_size(self, columns: Optional[Iterable[str]] = None) -> int:
         if columns is None:
@@ -278,7 +281,7 @@ class ParquetIndexWithMetadata:
             if len(row_group_offsets) == 0 or row_group_offsets[-1] == 0:  # if the dataset is empty
                 if offset < 0:
                     raise IndexError("Offset must be non-negative")
-                return parquet_files[0].read(), []
+                return cast_table_to_schema(parquet_files[0].read(), self.features.arrow_schema), []
 
             last_row_in_parquet = row_group_offsets[-1] - 1
             first_row = min(parquet_offset, last_row_in_parquet)
@@ -410,7 +413,7 @@ class ParquetIndexWithMetadata:
             if len(row_group_offsets) == 0 or row_group_offsets[-1] == 0:  # if the dataset is empty
                 if offset < 0:
                     raise IndexError("Offset must be non-negative")
-                return parquet_files[0].read()
+                return cast_table_to_schema(parquet_files[0].read(), self.features.arrow_schema)
 
             last_row_in_parquet = row_group_offsets[-1] - 1
             first_row = min(parquet_offset, last_row_in_parquet)

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -103,10 +103,6 @@ def create_rows_endpoint(
                                 )
                             else:
                                 pa_table = rows_index.query(offset=offset, length=length)
-                            features = Features(
-                                {col: rows_index.parquet_index.features[col] for col in pa_table.column_names}
-                            )
-                            pa_table = cast_table_to_features(pa_table, features)
                         except TooBigRows as err:
                             raise TooBigContentError(str(err)) from None
                     with StepProfiler(method="rows_endpoint", step="transform to a list"):

--- a/services/worker/src/worker/job_runners/split/first_rows.py
+++ b/services/worker/src/worker/job_runners/split/first_rows.py
@@ -104,7 +104,6 @@ def compute_first_rows_from_parquet_response(
                 pa_table, truncated_columns = rows_index.query_truncated_binary(offset=0, length=rows_max_number)
             else:
                 pa_table = rows_index.query(offset=0, length=rows_max_number)
-            pa_table = cast_table_to_features(pa_table, rows_index.parquet_index.features)
             return RowsContent(
                 rows=pa_table.to_pylist(),
                 all_fetched=rows_index.parquet_index.num_rows_total <= rows_max_number,


### PR DESCRIPTION
Sometimes a parquet dataset misses some columns from its `features` (e.g. defined in YAML)

This fixes it in the RowsIndex used for /first-rows and /rows