### PR TITLE
chore: update markdown formatting inside <Tip>

### DIFF
--- a/docs/source/postgresql.md
+++ b/docs/source/postgresql.md
@@ -46,7 +46,9 @@ select * from squad limit 10;
 ```
 
 <Tip>
+  
 Full documentation for the `ai.load_dataset` function can be found [here](https://github.com/timescale/pgai/blob/main/docs/load_dataset_from_huggingface.md).
+
 </Tip>
 
 ## Import only a subset of the dataset

--- a/docs/source/postgresql.md
+++ b/docs/source/postgresql.md
@@ -45,11 +45,7 @@ You can now query the table using standard SQL.
 select * from squad limit 10;
 ```
 
-<Tip>
-  
 Full documentation for the `ai.load_dataset` function can be found [here](https://github.com/timescale/pgai/blob/main/docs/load_dataset_from_huggingface.md).
-
-</Tip>
 
 ## Import only a subset of the dataset
 


### PR DESCRIPTION
Markdown formatting isn't working well inside the `<Tip>` element.

This might be affecting other pages as well, but this is the one I came across.