### PR TITLE
Add function to convert a feature name to a valid jsonpath.

### DIFF
--- a/libs/libcommon/src/libcommon/croissant_utils.py
+++ b/libs/libcommon/src/libcommon/croissant_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 The HuggingFace Authors.
 
+import re
 from collections.abc import Mapping
 from typing import Any, Optional, Union
 
@@ -66,7 +67,9 @@ HF_TO_CROISSANT_VALUE_TYPE = {
 def escape_jsonpath_key(feature_name: str) -> str:
     """Escape single quotes and brackets in the feature name so that it constitutes a valid JSONPath."""
     if "/" in feature_name or "'" in feature_name or "]" in feature_name or "[" in feature_name:
-        escaped_name = feature_name.replace("'", r"\'").replace("[", r"\[").replace("]", r"\]")
+        escaped_name = re.sub(r"(?<!\\)'", r"\'", feature_name)
+        escaped_name = re.sub(r"(?<!\\)\[", r"\[", escaped_name)
+        escaped_name = re.sub(r"(?<!\\)\]", r"\]", escaped_name)
         return f"['{escaped_name}']"
     return feature_name
 

--- a/libs/libcommon/src/libcommon/croissant_utils.py
+++ b/libs/libcommon/src/libcommon/croissant_utils.py
@@ -63,6 +63,14 @@ HF_TO_CROISSANT_VALUE_TYPE = {
 }
 
 
+def escape_jsonpath_key(feature_name: str) -> str:
+    """Escape single quotes and brackets in the feature name so that it constitutes a valid JSONPath."""
+    if "/" in feature_name or "'" in feature_name or "]" in feature_name or "[" in feature_name:
+        escaped_name = feature_name.replace("'", r"\'").replace("[", r"\[").replace("]", r"\]")
+        return f"['{escaped_name}']"
+    return feature_name
+
+
 def get_source(
     distribution_name: str, column: str, add_transform: bool, json_path: Optional[list[str]] = None
 ) -> dict[str, Any]:
@@ -117,7 +125,8 @@ def feature_to_croissant_field(
         if not json_path:
             json_path = []
         for subfeature_name, sub_feature in feature.items():
-            sub_json_path = json_path + [subfeature_name]
+            subfeature_jsonpath = escape_jsonpath_key(subfeature_name)
+            sub_json_path = json_path + [subfeature_jsonpath]
             f = feature_to_croissant_field(
                 distribution_name,
                 f"{field_name}/{subfeature_name}",

--- a/libs/libcommon/tests/test_croissant_utils.py
+++ b/libs/libcommon/tests/test_croissant_utils.py
@@ -42,6 +42,7 @@ def test_truncate_features_from_croissant_crumbs_response(num_columns: int) -> N
         ("feature'with'quote", r"['feature\'with\'quote']"),
         ("feature[with]brackets", r"['feature\[with\]brackets']"),
         ("feature[with/slash]'and'quote", r"['feature\[with/slash\]\'and\'quote']"),
+        (r"feature\'already\'escaped", r"['feature\'already\'escaped']"),
     ],
 )
 def test_escape_jsonpath_key(feature_name, expected_output):

--- a/libs/libcommon/tests/test_croissant_utils.py
+++ b/libs/libcommon/tests/test_croissant_utils.py
@@ -8,7 +8,11 @@ from unittest.mock import patch
 import pytest
 from datasets import Sequence, Value
 
-from libcommon.croissant_utils import feature_to_croissant_field, truncate_features_from_croissant_crumbs_response
+from libcommon.croissant_utils import (
+    escape_jsonpath_key,
+    feature_to_croissant_field,
+    truncate_features_from_croissant_crumbs_response,
+)
 
 
 @pytest.mark.parametrize("num_columns", [1, 3])
@@ -28,6 +32,21 @@ def test_truncate_features_from_croissant_crumbs_response(num_columns: int) -> N
     else:
         assert len(content["recordSet"][0]["field"]) == 2
         assert "max number of columns reached" in content["recordSet"][0]["description"]
+
+
+@pytest.mark.parametrize(
+    "feature_name, expected_output",
+    [
+        ("simple_feature", "simple_feature"),
+        ("feature/with/slash", "['feature/with/slash']"),
+        ("feature'with'quote", r"['feature\'with\'quote']"),
+        ("feature[with]brackets", r"['feature\[with\]brackets']"),
+        ("feature[with/slash]'and'quote", r"['feature\[with/slash\]\'and\'quote']"),
+    ],
+)
+def test_escape_jsonpath_key(feature_name, expected_output):
+    """Tests the escape_jsonpath_key function with various inputs."""
+    assert escape_jsonpath_key(feature_name) == expected_output
 
 
 @pytest.mark.parametrize(

--- a/libs/libcommon/tests/test_croissant_utils.py
+++ b/libs/libcommon/tests/test_croissant_utils.py
@@ -45,7 +45,7 @@ def test_truncate_features_from_croissant_crumbs_response(num_columns: int) -> N
         (r"feature\'already\'escaped", r"['feature\'already\'escaped']"),
     ],
 )
-def test_escape_jsonpath_key(feature_name, expected_output):
+def test_escape_jsonpath_key(feature_name: str, expected_output: str) -> None:
     """Tests the escape_jsonpath_key function with various inputs."""
     assert escape_jsonpath_key(feature_name) == expected_output
 


### PR DESCRIPTION
This is used to set the correct Transform operations.

This was needed in particular for this dataset: https://huggingface.co/datasets/allenai/WildChat-1M as some of its feature names contain slashes. This creates a problem when the slashes are included non-escaped as part of the json_path attribute of a Transform operation.

An example of the corrected croissant def, as it will be now generated by HF, is here: https://github.com/mlcommons/croissant/pull/829