### PR TITLE
Re-enable smart update for private and gated repos

### DIFF
--- a/libs/libcommon/src/libcommon/orchestrator.py
+++ b/libs/libcommon/src/libcommon/orchestrator.py
@@ -975,17 +975,17 @@ class SmartDatasetUpdatePlan(Plan):
                 )
 
     def get_diff(self) -> str:
-        # Temporary fix for https://github.com/huggingface-internal/moon-landing/pull/13232
-        # Don't use thee app token until it's allowed on this endpoint
-        # This way, it can still work for public repos
-        # headers = build_hf_headers(token=self.hf_token, library_name="dataset-viewer")
-        headers = build_hf_headers(library_name="dataset-viewer")
+        headers = build_hf_headers(token=self.hf_token, library_name="dataset-viewer")
         resp = get_session().get(
-            self.hf_endpoint + f"/datasets/{self.dataset}/commit/{self.revision}.diff", timeout=10, headers=headers
+            self.hf_endpoint + f"/api/datasets/{self.dataset}/compare/{self.revision}^..{self.revision}",
+            timeout=10,
+            headers=headers,
         )
         resp.raise_for_status()
         if not isinstance(resp.content, bytes):  # for mypy
-            raise RuntimeError(f"failed reading /datasets/{self.dataset}/commit/{self.revision}.diff")
+            raise RuntimeError(
+                f"failed reading /api/datasets/{self.dataset}/compare/{self.revision}^..{self.revision}"
+            )
         return resp.content.decode("utf-8")
 
     def get_impacted_files(self) -> set[str]:


### PR DESCRIPTION
The `/api/.../compare/:compare` endpoint does support app tokens, unlike `/:rev.diff`

and if I query the git comparison `{rev}^..{rev}` I get the same output as `/:rev.diff`, so no need to update the parsing

follows https://github.com/huggingface/dataset-viewer/pull/3163
original pr for smart updates: https://github.com/huggingface/dataset-viewer/pull/2788