### PR TITLE
Fix webhook repo config update

### DIFF
--- a/services/webhook/src/webhook/routes/webhook.py
+++ b/services/webhook/src/webhook/routes/webhook.py
@@ -84,17 +84,17 @@ def process_payload(
         # ^ it filters out the webhook calls for non-dataset repos and discussions in dataset repos
         return None
     dataset = payload["repo"]["name"]
-    private = payload["repo"]["private"]
     if dataset is None:
         return None
     event = payload["event"]
     if event == "remove":
         delete_dataset(dataset=dataset, storage_clients=storage_clients)
     elif event in ["add", "update", "move"]:
+        revision = payload["repo"]["headSha"]
         if (
             event == "update"
-            and get_current_revision(dataset) == payload["repo"]["headSha"]
-            and (not payload["scope"] == "repo.config" or not private)
+            and get_current_revision(dataset) == revision
+            and not payload.get("updatedConfig", {}).get("private", False)
         ):
             # ^ it filters out the webhook calls when the refs/convert/parquet branch is updated
             # ^ it also filters switching from private to public if the headSha is in the cache (i.e. if the user is PRO/Enterprise)
@@ -102,7 +102,6 @@ def process_payload(
                 f"Webhook revision for {dataset} is the same as the current revision in the db - skipping update."
             )
             return None
-        revision = payload["repo"].get("headSha")
         old_revision: Optional[str] = None
         for updated_ref in payload.get("updatedRefs") or []:
             ref = updated_ref.get("ref")


### PR DESCRIPTION
The viewer computes some datasets over and over again like https://huggingface.co/datasets/HuggingFaceH4/lighteval-mini-math, and right now we have a big queue partly because of that

This should fix the looping recomputations that seem to be due to webhooks with `'scope': 'repo.config'` and `'updatedConfig': {}`