### PR TITLE
Enable more datasets to work without `refs/convert/duckdb`

### DIFF
--- a/libs/libcommon/src/libcommon/duckdb_utils.py
+++ b/libs/libcommon/src/libcommon/duckdb_utils.py
@@ -24,7 +24,7 @@ DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERNS = [
     "openai/*",
     "EleutherAI/*",
     "HuggingFaceFW/*",
-    "TIGER-Lab/*", 
+    "TIGER-Lab/*",
     "Rapidata/*",  # images
     "MrDragonFox/*",  # audios
     "*NoDuckdbRef*",

--- a/libs/libcommon/src/libcommon/duckdb_utils.py
+++ b/libs/libcommon/src/libcommon/duckdb_utils.py
@@ -19,7 +19,16 @@ from libcommon.statistics_utils import (
     StringColumn,
 )
 
-DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERN = "*NoDuckdbRef*"
+DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERNS = [
+    "vevotx/*",
+    "openai/*",
+    "EleutherAI/*",
+    "HuggingFaceFW/*",
+    "TIGER-Lab/*", 
+    "Rapidata/*",  # images
+    "MrDragonFox/*",  # audios
+    "*NoDuckdbRef*",
+]
 
 DATASET_TYPE = "dataset"
 DEFAULT_STEMMER = "none"  # Exact word matches

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -33,7 +33,7 @@ from libapi.utils import (
     get_json_ok_response,
 )
 from libcommon.constants import ROW_IDX_COLUMN
-from libcommon.duckdb_utils import DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERN, duckdb_index_is_partial
+from libcommon.duckdb_utils import DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERNS, duckdb_index_is_partial
 from libcommon.prometheus import StepProfiler
 from libcommon.storage import StrPath, clean_dir
 from libcommon.storage_client import StorageClient
@@ -109,7 +109,7 @@ def create_filter_endpoint(
                         hf_jwt_algorithm=hf_jwt_algorithm,
                         hf_timeout_seconds=hf_timeout_seconds,
                     )
-                if fnmatch(dataset, DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERN):
+                if any(fnmatch(dataset, pat) for pat in DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERNS):
                     with StepProfiler(method="filter_endpoint", step="build index if missing"):
                         # get parquet urls and dataset_info
                         parquet_metadata_response = get_cache_entry_from_parquet_metadata_job(

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -36,7 +36,7 @@ from libapi.utils import (
 )
 from libcommon.constants import HF_FTS_SCORE, MAX_NUM_ROWS_PER_PAGE, ROW_IDX_COLUMN
 from libcommon.dtos import PaginatedResponse
-from libcommon.duckdb_utils import DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERN, duckdb_index_is_partial
+from libcommon.duckdb_utils import DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERNS, duckdb_index_is_partial
 from libcommon.prometheus import StepProfiler
 from libcommon.storage import StrPath, clean_dir
 from libcommon.storage_client import StorageClient
@@ -165,7 +165,7 @@ def create_search_endpoint(
 
                 logging.info(f"/search {dataset=} {config=} {split=} {query=} {offset=} {length=}")
 
-                if fnmatch(dataset, DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERN):
+                if any(fnmatch(dataset, pat) for pat in DISABLED_DUCKDB_REF_BRANCH_DATASET_NAME_PATTERNS):
                     with StepProfiler(method="filter_endpoint", step="build index if missing"):
                         # get parquet urls and dataset_info
                         parquet_metadata_response = get_cache_entry_from_parquet_metadata_job(


### PR DESCRIPTION
I spent some time trying to optimize the on-the-fly searching but couldn't find a way to make it faster.

It seems FTS indexing can take a couple minutes to run, maybe because of https://github.com/duckdb/duckdb-fts/issues/7

I tried not using FTS indexing but searching on 5GB without index takes 1min+ (or 15sec if you remove tokenization/stemming but you don't end up with great results)

For now I'll just enable more datasets to do more tests on other types of data (small text, big text, image and audio)