### PR TITLE
Fix empty result in search

### DIFF
--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -101,7 +101,8 @@ async def create_response(
 ) -> PaginatedResponse:
     features_without_key = features.copy()
     features_without_key.pop(ROW_IDX_COLUMN, None)
-    pa_table = pa_table.drop(unsupported_columns)
+    if len(pa_table) > 0:
+        pa_table = pa_table.drop(unsupported_columns)
     logging.info(f"create response for {dataset=} {config=} {split=}")
 
     return PaginatedResponse(


### PR DESCRIPTION
fix e.g. for /search dataset='nvidia/describe-anything-dataset' config='COCOStuff' split='train' query='pokemon' offset=0 length=100` with 0 results