### PR TITLE
Always truncate binary data

### DIFF
--- a/libs/libcommon/src/libcommon/viewer_utils/features.py
+++ b/libs/libcommon/src/libcommon/viewer_utils/features.py
@@ -38,7 +38,6 @@ from libcommon.viewer_utils.asset import (
     create_video_file,
 )
 
-UNSUPPORTED_FEATURES = [Value("binary")]
 AUDIO_FILE_MAGIC_NUMBERS: dict[str, Any] = {
     ".wav": [(b"\x52\x49\x46\x46", 0), (b"\x57\x41\x56\x45", 8)],  # AND: (magic_number, start)
     ".mp3": (b"\xff\xfb", b"\xff\xf3", b"\xff\xf2", b"\x49\x44\x33"),  # OR
@@ -464,7 +463,7 @@ def to_features_list(features: Features) -> list[FeatureItem]:
 
 def get_supported_unsupported_columns(
     features: Features,
-    unsupported_features: list[FeatureType] = UNSUPPORTED_FEATURES,
+    unsupported_features: list[FeatureType] = [],
 ) -> tuple[list[str], list[str]]:
     supported_columns, unsupported_columns = [], []
 

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -101,13 +101,10 @@ def create_rows_endpoint(
                         revision = rows_index.revision
                     with StepProfiler(method="rows_endpoint", step="query the rows"):
                         try:
-                            truncated_columns: list[str] = []
-                            if dataset == "Major-TOM/Core-S2L2A" or dataset == "foursquare/fsq-os-places":
-                                pa_table, truncated_columns = rows_index.query_truncated_binary(
-                                    offset=offset, length=length
-                                )
-                            else:
-                                pa_table = rows_index.query(offset=offset, length=length)
+                            # Some datasets have very long binary data that we truncate
+                            pa_table, truncated_columns = rows_index.query_truncated_binary(
+                                offset=offset, length=length
+                            )
                         except TooBigRows as err:
                             raise TooBigContentError(str(err)) from None
                     with StepProfiler(method="rows_endpoint", step="transform to a list"):

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -27,7 +27,6 @@ from libcommon.prometheus import StepProfiler
 from libcommon.simple_cache import CachedArtifactError, CachedArtifactNotFoundError
 from libcommon.storage import StrPath
 from libcommon.storage_client import StorageClient
-from libcommon.viewer_utils.features import UNSUPPORTED_FEATURES
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -59,7 +58,6 @@ def create_rows_endpoint(
         parquet_metadata_directory=parquet_metadata_directory,
         httpfs=HTTPFileSystem(headers={"authorization": f"Bearer {hf_token}"}),
         max_arrow_data_in_memory=max_arrow_data_in_memory,
-        unsupported_features=UNSUPPORTED_FEATURES,
         all_columns_supported_datasets_allow_list=ALL_COLUMNS_SUPPORTED_DATASETS_ALLOW_LIST,
     )
 

--- a/services/worker/src/worker/job_runners/split/first_rows.py
+++ b/services/worker/src/worker/job_runners/split/first_rows.py
@@ -98,11 +98,8 @@ def compute_first_rows_from_parquet_response(
     # get the rows
     def get_rows_content(rows_max_number: int) -> RowsContent:
         try:
-            truncated_columns: list[str] = []
-            if dataset == "Major-TOM/Core-S2L2A":
-                pa_table, truncated_columns = rows_index.query_truncated_binary(offset=0, length=rows_max_number)
-            else:
-                pa_table = rows_index.query(offset=0, length=rows_max_number)
+            # Some datasets have very long binary data that we truncate
+            pa_table, truncated_columns = rows_index.query_truncated_binary(offset=0, length=rows_max_number)
             return RowsContent(
                 rows=pa_table.to_pylist(),
                 all_fetched=rows_index.parquet_index.num_rows_total <= rows_max_number,


### PR DESCRIPTION
fix for https://huggingface.co/datasets/nvidia/describe-anything-dataset

- support binary for /rows, /filter and /search
- truncate too long binary data