### PR TITLE
Try multiprocessing for Pdf in /rows, /search and /filter

### DIFF
--- a/libs/libapi/src/libapi/response.py
+++ b/libs/libapi/src/libapi/response.py
@@ -25,6 +25,7 @@ async def create_response(
     partial: bool,
     use_row_idx_column: bool = False,
     truncated_columns: Optional[list[str]] = None,
+    picklable_storage_client: Optional[StorageClient] = None,
 ) -> PaginatedResponse:
     if set(pa_table.column_names).intersection(set(unsupported_columns)):
         raise RuntimeError(
@@ -49,6 +50,7 @@ async def create_response(
             unsupported_columns=unsupported_columns,
             row_idx_column=ROW_IDX_COLUMN if use_row_idx_column else None,
             truncated_columns=truncated_columns,
+            picklable_storage_client=picklable_storage_client,
         ),
         "num_rows_total": num_rows_total,
         "num_rows_per_page": MAX_NUM_ROWS_PER_PAGE,

--- a/libs/libapi/src/libapi/rows_utils.py
+++ b/libs/libapi/src/libapi/rows_utils.py
@@ -3,6 +3,7 @@
 
 from collections.abc import Callable
 from functools import partial
+from multiprocessing.pool import Pool
 from typing import Any, Optional
 
 import anyio
@@ -73,6 +74,9 @@ async def transform_rows(
         desc = f"_transform_row for {dataset}"
         _thread_map = partial(thread_map, desc=desc, total=len(rows))
         return await anyio.to_thread.run_sync(_thread_map, fn, enumerate(rows))
+    elif "Pdf(" in str(features):
+        # Use multiprocessing to parallelize PDF files uploads.
+        return await anyio.to_thread.run_sync(lambda rows: Pool().map(fn, rows), enumerate(rows))
     else:
 
         def _map(func: Callable[[Any], Any], *iterables: Any) -> list[Row]:

--- a/libs/libapi/src/libapi/utils.py
+++ b/libs/libapi/src/libapi/utils.py
@@ -229,10 +229,25 @@ async def to_rows_list(
             row_idx_column=row_idx_column,
         )
     except Exception as err:
+        error_message = str(err)
+        error_repr = repr(err)
         error_trace = traceback.format_exc()
-        raise TransformRowsProcessingError(
-            f"Server error while post-processing the split rows. Please report the issue.\nTraceback:\n{error_trace}"
-        ) from err
+
+        detailed_error = (
+            "[ERROR MESSAGE]: "
+            + error_message
+            + "\n"
+            + "[ERROR TYPE]: "
+            + type(err).__name__
+            + "\n"
+            + "[ERROR REPR]: "
+            + error_repr
+            + "\n"
+            + "[TRACEBACK]:\n"
+            + error_trace
+        )
+
+        raise TransformRowsProcessingError(f"Server error while post-processing.{detailed_error}") from err
     return [
         {
             "row_idx": idx + offset if row_idx_column is None else row.pop(row_idx_column),

--- a/libs/libapi/src/libapi/utils.py
+++ b/libs/libapi/src/libapi/utils.py
@@ -210,6 +210,7 @@ async def to_rows_list(
     storage_client: StorageClient,
     row_idx_column: Optional[str] = None,
     truncated_columns: Optional[list[str]] = None,
+    picklable_storage_client: Optional[StorageClient] = None,
 ) -> list[RowItem]:
     num_rows = pa_table.num_rows
     for idx, (column, feature) in enumerate(features.items()):
@@ -227,6 +228,7 @@ async def to_rows_list(
             storage_client=storage_client,
             offset=offset,
             row_idx_column=row_idx_column,
+            picklable_storage_client=picklable_storage_client,
         )
     except Exception as err:
         error_message = str(err)

--- a/libs/libapi/src/libapi/utils.py
+++ b/libs/libapi/src/libapi/utils.py
@@ -2,6 +2,7 @@
 # Copyright 2022 The HuggingFace Authors.
 
 import logging
+import traceback
 from collections.abc import Callable, Coroutine
 from http import HTTPStatus
 from typing import Any, Optional
@@ -228,8 +229,9 @@ async def to_rows_list(
             row_idx_column=row_idx_column,
         )
     except Exception as err:
+        error_trace = traceback.format_exc()
         raise TransformRowsProcessingError(
-            "Server error while post-processing the split rows. Please report the issue."
+            f"Server error while post-processing the split rows. Please report the issue.\nTraceback:\n{error_trace}"
         ) from err
     return [
         {

--- a/services/rows/src/rows/app.py
+++ b/services/rows/src/rows/app.py
@@ -79,6 +79,13 @@ def create_app_with_config(app_config: AppConfig) -> Starlette:
         s3_config=app_config.s3,
         # no need to specify a url_signer
     )
+    picklable_cached_assets_storage_client = StorageClient(
+        protocol=app_config.cached_assets.storage_protocol,
+        storage_root=app_config.cached_assets.storage_root,
+        base_url=app_config.cached_assets.base_url,
+        s3_config=app_config.s3,
+        url_preparator=None,  # to use in multiprocessing contexts
+    )
     storage_clients = [cached_assets_storage_client, assets_storage_client]
 
     resources: list[Resource] = [cache_resource, queue_resource]
@@ -107,6 +114,7 @@ def create_app_with_config(app_config: AppConfig) -> Starlette:
                 max_age_long=app_config.api.max_age_long,
                 max_age_short=app_config.api.max_age_short,
                 storage_clients=storage_clients,
+                picklable_cached_assets_storage_client=picklable_cached_assets_storage_client,
             ),
         ),
     ]

--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -52,6 +52,7 @@ def create_rows_endpoint(
     max_age_long: int = 0,
     max_age_short: int = 0,
     storage_clients: Optional[list[StorageClient]] = None,
+    picklable_cached_assets_storage_client: Optional[StorageClient] = None,
 ) -> Endpoint:
     indexer = Indexer(
         hf_token=hf_token,
@@ -119,6 +120,7 @@ def create_rows_endpoint(
                             partial=rows_index.parquet_index.partial,
                             num_rows_total=rows_index.parquet_index.num_rows_total,
                             truncated_columns=truncated_columns,
+                            picklable_storage_client=picklable_cached_assets_storage_client,
                         )
                 except CachedArtifactNotFoundError:
                     with StepProfiler(method="rows_endpoint", step="try backfill dataset"):

--- a/services/search/src/search/app.py
+++ b/services/search/src/search/app.py
@@ -83,6 +83,14 @@ def create_app_with_config(app_config: AppConfig) -> Starlette:
         s3_config=app_config.s3,
         # no need to specify a url_signer
     )
+    picklable_cached_assets_storage_client = StorageClient(
+        protocol=app_config.cached_assets.storage_protocol,
+        storage_root=app_config.cached_assets.storage_root,
+        base_url=app_config.cached_assets.base_url,
+        s3_config=app_config.s3,
+        url_preparator=None,  # to use in multiprocessing contexts
+    )
+
     storage_clients = [cached_assets_storage_client, assets_storage_client]
     resources: list[Resource] = [cache_resource, queue_resource]
     if not cache_resource.is_available():
@@ -113,6 +121,7 @@ def create_app_with_config(app_config: AppConfig) -> Starlette:
                 extensions_directory=app_config.duckdb_index.extensions_directory,
                 clean_cache_proba=app_config.duckdb_index.clean_cache_proba,
                 expiredTimeIntervalSeconds=app_config.duckdb_index.expired_time_interval_seconds,
+                picklable_cached_assets_storage_client=picklable_cached_assets_storage_client,
             ),
         ),
         Route(
@@ -134,6 +143,7 @@ def create_app_with_config(app_config: AppConfig) -> Starlette:
                 extensions_directory=app_config.duckdb_index.extensions_directory,
                 clean_cache_proba=app_config.duckdb_index.clean_cache_proba,
                 expiredTimeIntervalSeconds=app_config.duckdb_index.expired_time_interval_seconds,
+                picklable_cached_assets_storage_client=picklable_cached_assets_storage_client,
             ),
         ),
     ]

--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -76,6 +76,7 @@ def create_filter_endpoint(
     clean_cache_proba: float = 0.0,
     expiredTimeIntervalSeconds: int = 60,
     max_split_size_bytes: int = 5_000_000_000,
+    picklable_cached_assets_storage_client: Optional[StorageClient] = None,
 ) -> Endpoint:
     async def filter_endpoint(request: Request) -> Response:
         revision: Optional[str] = None
@@ -184,6 +185,7 @@ def create_filter_endpoint(
                         num_rows_total=num_rows_total,
                         partial=partial,
                         use_row_idx_column=True,
+                        picklable_storage_client=picklable_cached_assets_storage_client,
                     )
                 with StepProfiler(method="filter_endpoint", step="generate the OK response"):
                     return get_json_ok_response(content=response, max_age=max_age_long, revision=revision)

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -134,6 +134,7 @@ def create_search_endpoint(
     clean_cache_proba: float = 0.0,
     expiredTimeIntervalSeconds: int = 60,
     max_split_size_bytes: int = 5_000_000_000,
+    picklable_cached_assets_storage_client: Optional[StorageClient] = None,
 ) -> Endpoint:
     async def search_endpoint(request: Request) -> Response:
         revision: Optional[str] = None
@@ -238,6 +239,7 @@ def create_search_endpoint(
                         unsupported_columns=unsupported_columns,
                         num_rows_total=num_rows_total,
                         partial=partial,
+                        picklable_storage_client=picklable_cached_assets_storage_client,
                     )
                     logging.info(f"transform rows finished for {dataset=} {config=} {split=}")
                 with StepProfiler(method="search_endpoint", step="generate the OK response"):

--- a/services/search/src/search/routes/search.py
+++ b/services/search/src/search/routes/search.py
@@ -89,6 +89,7 @@ async def create_response(
     unsupported_columns: list[str],
     num_rows_total: int,
     partial: bool,
+    picklable_storage_client: Optional[StorageClient] = None,
 ) -> PaginatedResponse:
     features_without_key = features.copy()
     features_without_key.pop(ROW_IDX_COLUMN, None)
@@ -109,6 +110,7 @@ async def create_response(
             features=features,
             unsupported_columns=unsupported_columns,
             row_idx_column=ROW_IDX_COLUMN,
+            picklable_storage_client=picklable_storage_client,
         ),
         num_rows_total=num_rows_total,
         num_rows_per_page=MAX_NUM_ROWS_PER_PAGE,


### PR DESCRIPTION
Alternative to [huggingface/dataset-viewer#3198](https://github.com/huggingface/dataset-viewer/pull/3198).
This approach avoids using multiprocessing, which fails due to storage_client — specifically, the url_preparator (using CloudFrontSigner) is not picklable and cannot be passed between processes.

Proposal:
Instead of signing the URLs before processing, defer URL signing until after the PDF has been processed. This avoids pickling issues and keeps the parallel processing functional.