### PR TITLE
fix(cache_metrics): clamp negative total values before writing to DB

### DIFF
--- a/jobs/cache_maintenance/src/cache_maintenance/cache_metrics.py
+++ b/jobs/cache_maintenance/src/cache_maintenance/cache_metrics.py
@@ -31,9 +31,13 @@ def collect_cache_metrics() -> None:
         logging.info(f"{kind=} {http_status=} {error_code=} has been deleted")
 
     for (kind, http_status, error_code), total in new_metric_by_id.items():
+        if total < 0:
+            logging.warning(f"Corrected negative total for {kind=} {http_status=} {error_code=}: was {total}")
+        total = max(total, 0)
         CacheTotalMetricDocument.objects(kind=kind, http_status=http_status, error_code=error_code).upsert_one(
             total=total
         )
         logging.info(f"{kind=} {http_status=} {error_code=}: {total=} has been inserted")
+
 
     logging.info("cache metrics have been updated")


### PR DESCRIPTION
Fixes #2495

This PR ensures that `total` values stored in the cache metrics collection are never negative.

Specifically:
- In `collect_cache_metrics()`, we now clamp the `total` to `max(total, 0)` before calling `.upsert_one()`
- A warning is logged if a negative value is detected and corrected

While the `total` originates from `get_responses_count_by_kind_status_and_error_code()`, this fix guarantees data consistency at the write layer.