### PR TITLE
refactor(tests): use HfApi.update_repo_settings to simplify gated dataset test setup

### DIFF
--- a/jobs/cache_maintenance/tests/utils.py
+++ b/jobs/cache_maintenance/tests/utils.py
@@ -16,7 +16,6 @@ from huggingface_hub.constants import (
     REPO_TYPES_URL_PREFIXES,
 )
 from huggingface_hub.hf_api import HfApi
-from huggingface_hub.utils import hf_raise_for_status
 from libcommon.resources import Resource
 
 from .constants import (

--- a/jobs/cache_maintenance/tests/utils.py
+++ b/jobs/cache_maintenance/tests/utils.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 import requests
+from huggingface_hub import HfApi
 from huggingface_hub.community import DiscussionComment, DiscussionWithDetails
 from huggingface_hub.constants import (
     REPO_TYPE_DATASET,
@@ -37,75 +38,6 @@ def get_default_config_split() -> tuple[str, str]:
     split = "train"
     return config, split
 
-
-def update_repo_settings(
-    *,
-    repo_id: str,
-    private: Optional[bool] = None,
-    gated: Optional[str] = None,
-    token: Optional[str] = None,
-    organization: Optional[str] = None,
-    repo_type: Optional[str] = None,
-    name: Optional[str] = None,
-) -> Any:
-    """Update the settings of a repository.
-    Args:
-        repo_id (`str`, *optional*):
-            A namespace (user or an organization) and a repo name separated
-            by a `/`.
-            <Tip>
-            Version added: 0.5
-            </Tip>
-        private (`bool`, *optional*):
-            Whether the repo should be private.
-        gated (`str`, *optional*):
-            Whether the repo should request user access.
-            Possible values are 'auto' and 'manual'
-        token (`str`, *optional*):
-            An authentication token (See https://huggingface.co/settings/token)
-        repo_type (`str`, *optional*):
-            Set to `"dataset"` or `"space"` if uploading to a dataset or
-            space, `None` or `"model"` if uploading to a model.
-
-    Raises:
-        [~`huggingface_hub.utils.RepositoryNotFoundError`]:
-            If the repository to download from cannot be found. This may be because it doesn't exist,
-            or because it is set to `private` and you do not have access.
-
-    Returns:
-        `Any`: The HTTP response in json.
-    """
-    if repo_type not in REPO_TYPES:
-        raise ValueError("Invalid repo type")
-
-    organization, name = repo_id.split("/") if "/" in repo_id else (None, repo_id)
-
-    if organization is None:
-        namespace = hf_api.whoami(token)["name"]
-    else:
-        namespace = organization
-
-    path_prefix = f"{hf_api.endpoint}/api/"
-    if repo_type in REPO_TYPES_URL_PREFIXES:
-        path_prefix += REPO_TYPES_URL_PREFIXES[repo_type]
-
-    path = f"{path_prefix}{namespace}/{name}/settings"
-
-    json: dict[str, Union[bool, str]] = {}
-    if private is not None:
-        json["private"] = private
-    if gated is not None:
-        json["gated"] = gated
-
-    r = requests.put(
-        path,
-        headers={"authorization": f"Bearer {token}"},
-        json=json,
-    )
-    hf_raise_for_status(r)
-    return r.json()
-
-
 def create_empty_hub_dataset_repo(
     *,
     prefix: str,
@@ -117,7 +49,12 @@ def create_empty_hub_dataset_repo(
     repo_id = f"{CI_USER}/{dataset_name}"
     hf_api.create_repo(repo_id=repo_id, token=CI_USER_TOKEN, repo_type=DATASET, private=private)
     if gated:
-        update_repo_settings(repo_id=repo_id, token=CI_USER_TOKEN, gated=gated, repo_type=DATASET)
+        HfApi(endpoint=CI_HUB_ENDPOINT).update_repo_settings(
+            repo_id=repo_id,
+            token=CI_USER_TOKEN,
+            gated=gated,
+            repo_type=DATASET,
+        )
     if file_paths is not None:
         for file_path in file_paths:
             hf_api.upload_file(

--- a/services/admin/tests/fixtures/hub.py
+++ b/services/admin/tests/fixtures/hub.py
@@ -11,9 +11,7 @@ from typing import Any, Literal, Optional, TypedDict, Union
 import pytest
 import requests
 from huggingface_hub import HfApi
-from huggingface_hub.constants import REPO_TYPES, REPO_TYPES_URL_PREFIXES
 from huggingface_hub.hf_api import HfApi
-from huggingface_hub.utils import hf_raise_for_status
 
 # see https://github.com/huggingface/moon-landing/blob/main/server/scripts/staging-seed-db.ts
 CI_HUB_USER = "DVUser"

--- a/services/admin/tests/fixtures/hub.py
+++ b/services/admin/tests/fixtures/hub.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, Optional, TypedDict, Union
 
 import pytest
 import requests
+from huggingface_hub import HfApi
 from huggingface_hub.constants import REPO_TYPES, REPO_TYPES_URL_PREFIXES
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import hf_raise_for_status
@@ -19,75 +20,6 @@ CI_HUB_USER = "DVUser"
 CI_HUB_USER_API_TOKEN = "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"
 
 CI_HUB_ENDPOINT = "https://hub-ci.huggingface.co"
-
-
-def update_repo_settings(
-    hf_api: HfApi,
-    repo_id: str,
-    *,
-    private: Optional[bool] = None,
-    gated: Optional[str] = None,
-    token: Optional[str] = None,
-    organization: Optional[str] = None,
-    repo_type: Optional[str] = None,
-    name: Optional[str] = None,
-) -> Any:
-    """Update the settings of a repository.
-    Args:
-        repo_id (`str`, *optional*):
-            A namespace (user or an organization) and a repo name separated
-            by a `/`.
-            <Tip>
-            Version added: 0.5
-            </Tip>
-        private (`bool`, *optional*):
-            Whether the repo should be private.
-        gated (`str`, *optional*):
-            Whether the repo should request user access.
-            Possible values are 'auto' and 'manual'
-        token (`str`, *optional*):
-            An authentication token (See https://huggingface.co/settings/token)
-        repo_type (`str`, *optional*):
-            Set to `"dataset"` or `"space"` if uploading to a dataset or
-            space, `None` or `"model"` if uploading to a model.
-
-    Raises:
-        [~`huggingface_hub.utils.RepositoryNotFoundError`]:
-            If the repository to download from cannot be found. This may be because it doesn't exist,
-            or because it is set to `private` and you do not have access.
-
-    Returns:
-        `Any`: The HTTP response in json.
-    """
-    if repo_type not in REPO_TYPES:
-        raise ValueError("Invalid repo type")
-
-    organization, name = repo_id.split("/") if "/" in repo_id else (None, repo_id)
-
-    if organization is None:
-        namespace = hf_api.whoami(token=token)["name"]
-    else:
-        namespace = organization
-
-    path_prefix = f"{hf_api.endpoint}/api/"
-    if repo_type in REPO_TYPES_URL_PREFIXES:
-        path_prefix += REPO_TYPES_URL_PREFIXES[repo_type]
-
-    path = f"{path_prefix}{namespace}/{name}/settings"
-
-    json: dict[str, Union[bool, str]] = {}
-    if private is not None:
-        json["private"] = private
-    if gated is not None:
-        json["gated"] = gated
-
-    r = requests.put(
-        path,
-        headers={"authorization": f"Bearer {token}"},
-        json=json,
-    )
-    hf_raise_for_status(r)
-    return r.json()
 
 
 @pytest.fixture(scope="session")
@@ -129,7 +61,6 @@ def create_unique_repo_name(prefix: str, user: str) -> str:
     repo_name = f"{prefix}-{int(time.time() * 10e3)}"
     return f"{user}/{repo_name}"
 
-
 def create_hf_dataset_repo(
     hf_api: HfApi,
     hf_token: str,
@@ -142,9 +73,13 @@ def create_hf_dataset_repo(
     repo_id = create_unique_repo_name(prefix, user)
     hf_api.create_repo(repo_id=repo_id, token=hf_token, repo_type="dataset", private=private)
     if gated:
-        update_repo_settings(hf_api, repo_id, token=hf_token, gated=gated, repo_type="dataset")
+        hf_api.update_repo_settings(
+            repo_id=repo_id,
+            token=hf_token,
+            gated=gated,
+            repo_type="dataset",
+        )
     return repo_id
-
 
 # https://docs.pytest.org/en/6.2.x/fixture.html#yield-fixtures-recommended
 @pytest.fixture(scope="session", autouse=True)

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -14,9 +14,7 @@ import pytest
 import requests
 from datasets import Dataset, Features, Value
 from huggingface_hub import HfApi
-from huggingface_hub.constants import REPO_TYPES, REPO_TYPES_URL_PREFIXES
 from huggingface_hub.hf_api import HfApi
-from huggingface_hub.utils import hf_raise_for_status
 from libcommon.viewer_utils.asset import DATASET_GIT_REVISION_PLACEHOLDER
 
 from ..constants import ASSETS_BASE_URL, CI_HUB_ENDPOINT, CI_URL_TEMPLATE, CI_USER, CI_USER_TOKEN

--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -13,6 +13,7 @@ from typing import Any, Literal, Optional, TypedDict, Union
 import pytest
 import requests
 from datasets import Dataset, Features, Value
+from huggingface_hub import HfApi
 from huggingface_hub.constants import REPO_TYPES, REPO_TYPES_URL_PREFIXES
 from huggingface_hub.hf_api import HfApi
 from huggingface_hub.utils import hf_raise_for_status
@@ -30,75 +31,6 @@ def get_default_config_split() -> tuple[str, str]:
     config = "default"
     split = "train"
     return config, split
-
-
-def update_repo_settings(
-    *,
-    repo_id: str,
-    private: Optional[bool] = None,
-    gated: Optional[str] = None,
-    token: Optional[str] = None,
-    organization: Optional[str] = None,
-    repo_type: Optional[str] = None,
-    name: Optional[str] = None,
-) -> Any:
-    """Update the settings of a repository.
-
-    Args:
-        repo_id (`str`, *optional*):
-            A namespace (user or an organization) and a repo name separated
-            by a `/`.
-            <Tip>
-            Version added: 0.5
-            </Tip>
-        private (`bool`, *optional*):
-            Whether the repo should be private.
-        gated (`str`, *optional*):
-            Whether the repo should request user access.
-            Possible values are 'auto' and 'manual'
-        token (`str`, *optional*):
-            An authentication token (See https://huggingface.co/settings/token)
-        repo_type (`str`, *optional*):
-            Set to `"dataset"` or `"space"` if uploading to a dataset or
-            space, `None` or `"model"` if uploading to a model.
-
-    Raises:
-        [~`huggingface_hub.utils.RepositoryNotFoundError`]:
-            If the repository to download from cannot be found. This may be because it doesn't exist,
-            or because it is set to `private` and you do not have access.
-
-    Returns:
-        `Any`: The HTTP response in json.
-    """
-    if repo_type not in REPO_TYPES:
-        raise ValueError("Invalid repo type")
-
-    organization, name = repo_id.split("/") if "/" in repo_id else (None, repo_id)
-
-    if organization is None:
-        namespace = hf_api.whoami(token)["name"]
-    else:
-        namespace = organization
-
-    path_prefix = f"{hf_api.endpoint}/api/"
-    if repo_type in REPO_TYPES_URL_PREFIXES:
-        path_prefix += REPO_TYPES_URL_PREFIXES[repo_type]
-
-    path = f"{path_prefix}{namespace}/{name}/settings"
-
-    json: dict[str, Union[bool, str]] = {}
-    if private is not None:
-        json["private"] = private
-    if gated is not None:
-        json["gated"] = gated
-
-    r = requests.put(
-        path,
-        headers={"authorization": f"Bearer {token}"},
-        json=json,
-    )
-    hf_raise_for_status(r)
-    return r.json()
 
 
 def create_hub_dataset_repo(
@@ -125,8 +57,15 @@ def create_hub_dataset_repo(
             )
     else:
         hf_api.create_repo(repo_id=repo_id, token=CI_USER_TOKEN, repo_type=DATASET, private=private)
+    
     if gated:
-        update_repo_settings(repo_id=repo_id, token=CI_USER_TOKEN, gated=gated, repo_type=DATASET)
+        HfApi(endpoint=CI_HUB_ENDPOINT).update_repo_settings(
+            repo_id=repo_id,
+            token=CI_USER_TOKEN,
+            gated=gated,
+            repo_type=DATASET,
+        )
+        
     if file_paths is not None:
         for file_path in file_paths:
             hf_api.upload_file(


### PR DESCRIPTION
Now that `huggingface_hub>=0.25.0` supports the `gated` parameter in `HfApi.update_repo_settings`, this PR removes the custom implementations of `update_repo_settings()` from internal test utilities.

### Changes made:
- Removed redundant `update_repo_settings()` function from:
  - `jobs/cache_maintenance/tests/utils.py`
  - `services/admin/tests/fixtures/hub.py`
  - `services/worker/tests/fixtures/hub.py`
- Replaced each usage with the official `HfApi.update_repo_settings(...)` method
- Cleaned up related unused imports (`hf_raise_for_status`, `REPO_TYPES`, `REPO_TYPES_URL_PREFIXES`)

This is a pure cleanup refactor — it introduces no functional or behavioral changes.

Closes: #3063
