### PR TITLE
feat(rows): exclude heavy binary columns from /rows response to avoid UI lag (#3052)

### DIFF
--- a/services/rows/src/rows/routes/rows.py
+++ b/services/rows/src/rows/routes/rows.py
@@ -37,6 +37,7 @@ ALL_COLUMNS_SUPPORTED_DATASETS_ALLOW_LIST: Union[Literal["all"], list[str]] = [
     "halabi2016/arabic_speech_corpus"
 ]  # for testing
 
+EXCLUDED_COLUMNS = {"vae_latents", "t5_prompt_embeds"}
 
 def create_rows_endpoint(
     cached_assets_storage_client: StorageClient,
@@ -106,6 +107,7 @@ def create_rows_endpoint(
                         except TooBigRows as err:
                             raise TooBigContentError(str(err)) from None
                     with StepProfiler(method="rows_endpoint", step="transform to a list"):
+                        pa_table = pa_table.drop([col for col in pa_table.column_names if col in EXCLUDED_COLUMNS])
                         response = await create_response(
                             dataset=dataset,
                             revision=revision,


### PR DESCRIPTION
Fixes: #3052

This PR improves the responsiveness of the Dataset Viewer by skipping binary-heavy columns (e.g., `t5_prompt_embeds`, `vae_latents`) from the `/rows` endpoint payload.

These columns typically contain thousands of bytes per row and are not meaningful in the UI. The change introduces a hardcoded exclusion list (`EXCLUDED_COLUMNS`) and drops those columns from the final `pyarrow.Table` before response generation.

Tested manually using datasets with large binary columns and confirmed a reduction in payload size and frontend lag.

Future improvements could include:
- Auto-detecting such columns by dtype or size
- Allowing dataset creators to opt-out columns explicitly via config or metadata