### PR TITLE
build: upgrade pylance to 9.0.1

### DIFF
--- a/front/admin_ui/poetry.lock
+++ b/front/admin_ui/poetry.lock
@@ -1850,7 +1850,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -3299,30 +3299,31 @@ files = [
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]

--- a/jobs/cache_maintenance/poetry.lock
+++ b/jobs/cache_maintenance/poetry.lock
@@ -1387,7 +1387,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -3291,30 +3291,31 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]

--- a/jobs/mongodb_migration/poetry.lock
+++ b/jobs/mongodb_migration/poetry.lock
@@ -1387,7 +1387,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -3291,30 +3291,31 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]

--- a/libs/libapi/poetry.lock
+++ b/libs/libapi/poetry.lock
@@ -1406,7 +1406,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -3328,30 +3328,31 @@ crypto = ["cryptography (>=3.4.0)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]

--- a/libs/libcommon/poetry.lock
+++ b/libs/libcommon/poetry.lock
@@ -5474,4 +5474,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "3.14.5"
-content-hash = "6fcf10931463dd2ae6b0f50c003cab1929d494d16fb5ca770ee2ed3defd67f93"
+content-hash = "bf4415a5355d51aee7e6738aadf3effa2ef1f9fd7744d6203dc07ecf8c769523"

--- a/libs/libcommon/poetry.lock
+++ b/libs/libcommon/poetry.lock
@@ -3305,30 +3305,31 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]
@@ -5471,4 +5472,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "3.14.5"
-content-hash = "dc60fbc53ea16ae6f8d6899a6345ef935f620380a662a31f525f3b011a30432a"
+content-hash = "6fcf10931463dd2ae6b0f50c003cab1929d494d16fb5ca770ee2ed3defd67f93"

--- a/libs/libcommon/pyproject.toml
+++ b/libs/libcommon/pyproject.toml
@@ -31,7 +31,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
 pymongo = { extras = ["srv", "aws"], version = "^4.15.1" }

--- a/libs/libcommon/src/libcommon/scripts.py
+++ b/libs/libcommon/src/libcommon/scripts.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 
 def cli_all_projects() -> None:
-    all_projects_dir = Path(__file__).resolve().parents[-5]
+    all_projects_dir = Path(__file__).resolve().parents[4]
     projects = [
         p
         for d in all_projects_dir.glob("*")

--- a/services/admin/poetry.lock
+++ b/services/admin/poetry.lock
@@ -1370,6 +1370,7 @@ orjson = "^3.9.15"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
 starlette = ">=1.0.1,<2.0"
 starlette-prometheus = "^0.9.0"
+uvicorn = "^0.30.1"
 
 [package.source]
 type = "directory"
@@ -1410,7 +1411,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -3332,30 +3333,31 @@ crypto = ["cryptography (>=3.4.0)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]

--- a/services/api/poetry.lock
+++ b/services/api/poetry.lock
@@ -1407,6 +1407,7 @@ orjson = "^3.9.15"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
 starlette = ">=1.0.1,<2.0"
 starlette-prometheus = "^0.9.0"
+uvicorn = "^0.30.1"
 
 [package.source]
 type = "directory"
@@ -1447,7 +1448,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -3369,30 +3370,31 @@ crypto = ["cryptography (>=3.4.0)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]

--- a/services/rows/poetry.lock
+++ b/services/rows/poetry.lock
@@ -1408,6 +1408,7 @@ orjson = "^3.9.15"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
 starlette = ">=1.0.1,<2.0"
 starlette-prometheus = "^0.9.0"
+uvicorn = "^0.30.1"
 
 [package.source]
 type = "directory"
@@ -1448,7 +1449,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -3415,30 +3416,31 @@ crypto = ["cryptography (>=3.4.0)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]

--- a/services/search/poetry.lock
+++ b/services/search/poetry.lock
@@ -1407,6 +1407,7 @@ orjson = "^3.9.15"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
 starlette = ">=1.0.1,<2.0"
 starlette-prometheus = "^0.9.0"
+uvicorn = "^0.30.1"
 
 [package.source]
 type = "directory"
@@ -1447,7 +1448,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -3369,30 +3370,31 @@ crypto = ["cryptography (>=3.4.0)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]

--- a/services/sse-api/poetry.lock
+++ b/services/sse-api/poetry.lock
@@ -1442,6 +1442,7 @@ orjson = "^3.9.15"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
 starlette = ">=1.0.1,<2.0"
 starlette-prometheus = "^0.9.0"
+uvicorn = "^0.30.1"
 
 [package.source]
 type = "directory"
@@ -1482,7 +1483,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -3448,30 +3449,31 @@ crypto = ["cryptography (>=3.4.0)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]

--- a/services/webhook/poetry.lock
+++ b/services/webhook/poetry.lock
@@ -1407,6 +1407,7 @@ orjson = "^3.9.15"
 pyjwt = {version = "^2.6.0", extras = ["crypto"]}
 starlette = ">=1.0.1,<2.0"
 starlette-prometheus = "^0.9.0"
+uvicorn = "^0.30.1"
 
 [package.source]
 type = "directory"
@@ -1447,7 +1448,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -3369,30 +3370,31 @@ crypto = ["cryptography (>=3.4.0)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]

--- a/services/worker/poetry.lock
+++ b/services/worker/poetry.lock
@@ -1800,7 +1800,7 @@ polars = "1.39.3"
 psutil = "^7.1.0"
 pyarrow = "^22.0.0"
 pydantic = "^2.12.5"
-pylance = "^1.0.4"
+pylance = "^9.0.1"
 pymongo = {version = "^4.15.1", extras = ["aws", "srv"]}
 pymongoarrow = "^1.10.0"
 pymupdf = "^1.26.1"
@@ -4137,30 +4137,31 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylance"
-version = "1.0.4"
+version = "9.0.1"
 description = "python wrapper for Lance columnar format"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pylance-1.0.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00f0dd1677e7eaec625626a054ddd340dbbcdaf915638c5aae6b2c950a571855"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7341a96b6a3952aad399581818d2e2f8ad426d6248498dbb7fb12f235eded8af"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b42f72ce1cf8158adaa7b444d98328b8009683641dd7be58678c7236edbd8be"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f9512087f0fd024f18a4500e62fc27f05b02d92740faed5b9cd140ffadaff82"},
-    {file = "pylance-1.0.4-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3f208682b476a0eacb20a44b6fa5c4e67a32ab76cf3199a7bf5f95fecad32020"},
-    {file = "pylance-1.0.4-cp39-abi3-win_amd64.whl", hash = "sha256:64cd1818adb4b5aa141aff3dce99e5db26d033628cdd84192c5d880acc93454b"},
+    {file = "pylance-9.0.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:951718d675a0819d994a47d650899a40d6a2a4b05f4546481c8c909738e643e9"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e848de293a31663cd25f0f3d7304fe5bef44ce68bb950452bb91ac1f7b7096a4"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353e4fa6d9a49ab98b16709482cf8943f73f2ce0fea3d63ea5872a8891b4e870"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fb77aff57d44228cf038366d1edd5f5857b411ba3acea7efd0319a9d5f8bb9e7"},
+    {file = "pylance-9.0.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7a8b32eecf5b99e9195512924154a1a55e39f3a9832f8c13fe6c6b74511033bb"},
+    {file = "pylance-9.0.1-cp310-abi3-win_amd64.whl", hash = "sha256:46fad09c7056267b5be42d573e1dada41bdcd7f7a67ede02fbcf86612b5de263"},
 ]
 
 [package.dependencies]
-lance-namespace = ">=0.4.5"
+lance-namespace = ">=0.8.5,<0.9"
 numpy = ">=1.22"
 pyarrow = ">=14"
 
 [package.extras]
 benchmarks = ["pytest-benchmark"]
-dev = ["pyright", "ruff (==0.4.1)"]
+dev = ["pyright", "ruff (==0.11.2)"]
 geo = ["geoarrow-rust-core", "geoarrow-rust-io"]
-tests = ["boto3", "datafusion (>=50.1)", "datasets", "duckdb", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tensorflow ; sys_platform == \"linux\"", "tqdm"]
+otel = ["opentelemetry-api", "opentelemetry-sdk"]
+tests = ["boto3", "datafusion (>=54,<55)", "datasets (==4.4.0)", "duckdb (>=1.5.0,<1.6.0)", "ml-dtypes", "pandas", "pillow", "polars[pandas,pyarrow]", "psutil", "pytest", "tqdm"]
 torch = ["torch (>=2.0)"]
 
 [[package]]


### PR DESCRIPTION
Upgrade `pylance` (the Python wrapper for the Lance columnar format) from 1.0.4 to the latest 9.0.1 in `libs/libcommon/pyproject.toml` and regenerate the affected `poetry.lock` files.

- 9.0.1 requires Python >=3.10; the repo already targets 3.14.5, so there is no conflict.
- Its new `lance-namespace >=0.8.5,<0.9` constraint is satisfied by the already-locked 0.8.6, so no other dependency changed.
- Regenerating the locks also picked up a pre-existing drift: `libs/libapi/pyproject.toml` declares `uvicorn = "^0.30.1"`, but the downstream service locks were missing it. This is now reflected in the admin/api/rows/search/sse-api/webhook locks.
