### PR TITLE
feat(chart): add deny-all egress NetworkPolicy for the workers

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -60,6 +60,12 @@ enabled on the driver. Two consequences worth knowing:
 Local development, the tests and the e2e suite leave both modes off, and the services keep reading
 their usual environment variables.
 
+## Network policy (`networkPolicy.enabled`)
+
+The chart ships an optional egress `NetworkPolicy` for its pods, off by default. Egress is denied except
+DNS and the CIDRs in `networkPolicy.allowedCIDRs`, which is empty here and supplied via the values at
+deploy time. Enabling it without an allow-list leaves the pods with DNS only.
+
 ## Deploy
 
 To deploy, go to https://cd.internal.huggingface.tech/applications.

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The HuggingFace Authors.
+
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels: {{ include "hf.labels.commons" . | nindent 4 }}
+  name: "{{ include "name" . }}-egress"
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    {{- if .Values.networkPolicy.allNamespacePods }}
+    {}
+    {{- else }}
+    matchLabels: {{ include "hf.labels.commons" . | nindent 6 }}
+    {{- end }}
+  policyTypes:
+    - Egress
+  # Anything not matched below is denied.
+  egress:
+  {{- if or .Values.networkPolicy.allowDNS .Values.networkPolicy.allowedCIDRs .Values.networkPolicy.extraEgress }}
+    {{- if .Values.networkPolicy.allowDNS }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- range .Values.networkPolicy.allowedCIDRs }}
+    - to:
+        - ipBlock:
+            cidr: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- else }} []
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -225,6 +225,15 @@ persistence:
 monitoring:
   enabled: false
 
+# Optional deny-all egress NetworkPolicy for the pods of the release. The allowed destinations are
+# supplied via these values at deploy time; with the empty default below it denies all egress but DNS.
+networkPolicy:
+  enabled: false
+  allNamespacePods: false
+  allowedCIDRs: []
+  allowDNS: true
+  extraEgress: []
+
 mongodb:
   enabled: true
   nameOverride: datasets-server-mongodb


### PR DESCRIPTION
## What

Adds an optional egress `NetworkPolicy` (`networkPolicy.*`), **off by default**. Deny-all egress: only DNS and the CIDRs in `networkPolicy.allowedCIDRs` are allowed; the allow-list is set at deploy time (empty in the chart).

## Why

Defense-in-depth for the workers, which fetch URLs coming from dataset content (SSRF surface).

