### PR TITLE
fix(worker): add SSRF egress guard blocking internal/link-local fetches

### DIFF
--- a/libs/libcommon/src/libcommon/fsspec.py
+++ b/libs/libcommon/src/libcommon/fsspec.py
@@ -1,5 +1,15 @@
-from fsspec.registry import known_implementations
+from fsspec.registry import _registry, known_implementations
+
+ALLOWED_PROTOCOLS = ["hf", "s3", "zip", "file", "local"]
 
 for name in list(known_implementations):
-    if name not in ["hf", "s3", "zip", "file", "local"]:
+    if name not in ALLOWED_PROTOCOLS:
         del known_implementations[name]
+
+# `get_filesystem_class` looks the protocol up in the registry of the already imported filesystems
+# before falling back to `known_implementations`, so removing it from the latter is not enough: a
+# protocol that was imported before this module runs would stay usable. Note that it only stays
+# usable under the name it was imported with, e.g. "https" keeps working while "http" is refused.
+for name in list(_registry):
+    if name not in ALLOWED_PROTOCOLS:
+        del _registry[name]

--- a/libs/libcommon/src/libcommon/ssrf.py
+++ b/libs/libcommon/src/libcommon/ssrf.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The HuggingFace Authors.
+
+"""Egress guard against SSRF.
+
+The worker fetches URLs that come from dataset content: the `data_files` patterns declared in a
+dataset card, and the `path` of the media values stored in a dataset's Parquet files. Without a
+guard, a dataset can make the worker request internal endpoints: the cloud metadata service,
+in-cluster services, or anything else routable from the pod.
+
+The checks apply to the IP addresses the connections are opened to, not to the hostname, so they
+also cover a hostname that resolves to an internal address and a redirect to an internal host. Both
+guarded transports connect to an address that has been checked rather than resolving the host again,
+so a host that answers differently at connect time does not get through either. The transports that
+are guarded are the ones used to fetch dataset content:
+
+- `aiohttp`, the transport of `fsspec`'s `HTTPFileSystem` - which `datasets` uses to stream the data
+  files - and of `s3fs`,
+- `httpx`, the transport of `huggingface_hub`, which `datasets` also uses to send a HEAD request to
+  the URL of a data file before opening it.
+"""
+
+import socket
+from collections.abc import Iterable
+from ipaddress import IPv4Address, IPv6Address, ip_address
+from typing import Any, Optional, Union
+from urllib.parse import urlsplit
+
+import aiohttp
+import aiohttp.client
+import httpx
+from aiohttp.abc import ResolveResult
+from aiohttp.connector import AddrInfoType
+from httpcore import SOCKET_OPTION, ConnectError, ConnectTimeout, NetworkStream, SyncBackend
+from huggingface_hub import set_client_factory
+from huggingface_hub.utils._http import default_client_factory
+
+# The EC2 instance metadata service and the ECS task credentials endpoint. Both are link-local, so
+# they are already refused by `is_blocked_address`; they are listed to make the intent explicit.
+METADATA_ADDRESSES = frozenset({IPv4Address("169.254.169.254"), IPv4Address("169.254.170.2")})
+
+
+class BlockedAddressError(OSError):
+    """An outbound connection was refused because its target is not a public address.
+
+    It derives from `OSError` so that `aiohttp` and `httpx` report it the same way as any other
+    connection failure, instead of leaking through their retry and error handling.
+    """
+
+
+def is_blocked_address(address: str) -> bool:
+    """Whether an IP address is outside the public internet, and must not be connected to.
+
+    `is_global` is false for loopback, private (RFC 1918), shared (100.64.0.0/10), link-local
+    (169.254.0.0/16 and fe80::/10), unique-local (fc00::/7) and reserved addresses, but it is true
+    for multicast ones, hence the extra check.
+
+    Args:
+        address (`str`): An IP address, as returned by a resolver.
+
+    Returns:
+        `bool`: Whether connecting to the address must be refused.
+    """
+    ip: Union[IPv4Address, IPv6Address] = ip_address(address)
+    if isinstance(ip, IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return ip in METADATA_ADDRESSES or ip.is_multicast or not ip.is_global
+
+
+def raise_if_blocked_url(url: str) -> None:
+    """Refuse a URL whose host resolves to a non-public address.
+
+    This resolves the host itself, and is therefore only a pre-flight check: a host that changes its
+    answer between this call and the connection is stopped by the transports - `GuardedTCPConnector`
+    and `GuardedNetworkBackend` - which connect to an address they have checked.
+
+    Raises:
+        [~`libcommon.ssrf.BlockedAddressError`]: If the host resolves to a non-public address.
+    """
+    host = urlsplit(url).hostname
+    if host is None:
+        return
+    for _, _, _, _, sockaddr in socket.getaddrinfo(host, None, type=socket.SOCK_STREAM):
+        address = str(sockaddr[0])
+        if is_blocked_address(address):
+            raise BlockedAddressError(f"Refusing to connect to {host} ({address}): not a public address")
+
+
+def guarded_socket_factory(addr_info: AddrInfoType) -> socket.socket:
+    """Create the socket `aiohttp` is about to connect, once the address it will use is checked.
+
+    This is the last step before `connect()`, so it is what makes the check apply to the address
+    actually used, whatever the URL contained and whatever DNS answered in between.
+
+    Raises:
+        [~`libcommon.ssrf.BlockedAddressError`]: If the address is not a public one.
+    """
+    family, type_, proto, _, sockaddr = addr_info
+    address = str(sockaddr[0])
+    if is_blocked_address(address):
+        raise BlockedAddressError(f"Refusing to connect to {address}: not a public address")
+    return socket.socket(family=family, type=type_, proto=proto)
+
+
+class GuardedTCPConnector(aiohttp.TCPConnector):
+    """`TCPConnector` that refuses to connect to non-public addresses."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("socket_factory", guarded_socket_factory)
+        super().__init__(*args, **kwargs)
+
+    async def _resolve_host(self, host: str, port: int, traces: Optional[Any] = None) -> list[ResolveResult]:
+        # `TCPConnector._resolve_host` returns the addresses that will be connected to, and returns
+        # the host as-is - without calling the resolver - when it already is an IP address. Dropping
+        # the blocked ones here pins the connection to the addresses that have been checked.
+        results = await super()._resolve_host(host, port, traces=traces)
+        allowed = [result for result in results if not is_blocked_address(result["host"])]
+        if not allowed:
+            raise BlockedAddressError(f"Refusing to connect to {host}: it resolves to non-public addresses only")
+        return allowed
+
+
+def _check_httpx_request(request: httpx.Request) -> None:
+    raise_if_blocked_url(str(request.url))
+
+
+def guard_httpx_client(client: httpx.Client) -> httpx.Client:
+    """Make an `httpx.Client` refuse the requests whose host resolves to a non-public address.
+
+    This is the pre-flight check: it fails before a socket is opened, and it runs once per request so
+    it also runs on every hop of a redirect chain. `GuardedHTTPTransport` is what checks the address
+    the connection actually uses.
+    """
+    client.event_hooks["request"].append(_check_httpx_request)
+    return client
+
+
+class GuardedNetworkBackend(SyncBackend):
+    """`httpcore` backend that connects to a checked address instead of resolving the host again.
+
+    `SyncBackend.connect_tcp` hands the hostname to `socket.create_connection`, which resolves it
+    itself, so checking the host before the request leaves a window in which DNS can answer an
+    internal address at connect time. Resolving here and connecting to one of the checked addresses
+    closes it.
+
+    `httpcore` takes the name used for SNI and for the certificate check from the request URL, not
+    from what is connected to, so handing it an address leaves TLS unchanged.
+    """
+
+    def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: Optional[float] = None,
+        local_address: Optional[str] = None,
+        socket_options: Optional[Iterable[SOCKET_OPTION]] = None,
+    ) -> NetworkStream:
+        resolved = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        allowed = [str(sockaddr[0]) for *_, sockaddr in resolved if not is_blocked_address(str(sockaddr[0]))]
+        if not allowed:
+            raise BlockedAddressError(f"Refusing to connect to {host}: it resolves to non-public addresses only")
+        for address in allowed[:-1]:
+            try:
+                return self._connect_tcp_to_address(address, port, timeout, local_address, socket_options)
+            except (ConnectError, ConnectTimeout):
+                # keep the fallback on the next address that `socket.create_connection` would do
+                pass
+        return self._connect_tcp_to_address(allowed[-1], port, timeout, local_address, socket_options)
+
+    def _connect_tcp_to_address(
+        self,
+        address: str,
+        port: int,
+        timeout: Optional[float],
+        local_address: Optional[str],
+        socket_options: Optional[Iterable[SOCKET_OPTION]],
+    ) -> NetworkStream:
+        return super().connect_tcp(
+            address, port, timeout=timeout, local_address=local_address, socket_options=socket_options
+        )
+
+
+class GuardedHTTPTransport(httpx.HTTPTransport):
+    """`HTTPTransport` that connects only to the addresses that have been checked."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # the pool is configured by httpx, TLS context included, so only the backend that opens the
+        # connections is replaced
+        self._pool._network_backend = GuardedNetworkBackend()
+
+
+def _guarded_client_factory() -> httpx.Client:
+    client = guard_httpx_client(default_client_factory())
+    client._transport = GuardedHTTPTransport()
+    return client
+
+
+def install_ssrf_guard() -> None:
+    """Make the HTTP clients that fetch dataset content refuse non-public addresses.
+
+    Calling it is idempotent. It must be done before the first request, so that no client is created
+    from the unguarded defaults.
+    """
+    aiohttp.TCPConnector = GuardedTCPConnector  # type: ignore[misc]
+    aiohttp.client.TCPConnector = GuardedTCPConnector  # type: ignore[misc]
+    # ^ `ClientSession` builds its connector from `aiohttp.client.TCPConnector`, while third-party
+    # code - `aiobotocore`, hence `s3fs` - builds it from `aiohttp.TCPConnector`
+    set_client_factory(_guarded_client_factory)

--- a/libs/libcommon/src/libcommon/statistics_utils.py
+++ b/libs/libcommon/src/libcommon/statistics_utils.py
@@ -718,7 +718,14 @@ class MediaColumn(Column):
             if example["bytes"] is not None:
                 return io.BytesIO(example["bytes"])
             else:
-                return xopen(example["path"], "rb", download_config=DownloadConfig(token=hf_token))  # type: ignore
+                path = example["path"]
+                if not path.startswith("hf://"):
+                    # The media values that are not embedded in the Parquet files keep the path they
+                    # had in the dataset, which can be any URL. This has to stay before `xopen`:
+                    # `xopen` sends a request through `huggingface_hub` before it looks the protocol
+                    # up in fsspec, so the fsspec allow-list does not cover this path.
+                    raise ValueError(f"Media file doesn't belong to the Hub: {path}")
+                return xopen(path, "rb", download_config=DownloadConfig(token=hf_token))  # type: ignore
         elif isinstance(example, bytes):
             return io.BytesIO(example)
         else:

--- a/libs/libcommon/tests/test_fsspec.py
+++ b/libs/libcommon/tests/test_fsspec.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import fsspec
 import pytest
 
@@ -10,3 +13,32 @@ def test_fsspec(tmpfs: fsspec.AbstractFileSystem) -> None:
         fsspec.open("simplecache::tmp://data.txt")
     with pytest.raises(ValueError):
         fsspec.open("data:,Hello%2C%20World%21")
+
+
+@pytest.mark.parametrize("url", ["http://example.org/data.csv", "https://example.org/data.csv"])
+def test_fsspec_refuses_http(url: str) -> None:
+    with pytest.raises(ValueError, match="Protocol not known"):
+        fsspec.core.url_to_fs(url)
+
+
+# imports the HTTP filesystem before `libcommon`, i.e. before the protocols are removed
+IMPORT_HTTP_FILESYSTEM_FIRST = """
+import fsspec
+
+fsspec.get_filesystem_class("https")
+
+import libcommon  # noqa: F401
+
+for url in ["http://example.org/data.csv", "https://example.org/data.csv"]:
+    try:
+        fsspec.core.url_to_fs(url)
+    except ValueError:
+        continue
+    raise AssertionError(f"{url} is still allowed")
+assert fsspec.get_filesystem_class("hf")
+"""
+
+
+def test_fsspec_refuses_http_whatever_the_import_order() -> None:
+    # in a new process, since the import order is what is being checked
+    subprocess.run([sys.executable, "-c", IMPORT_HTTP_FILESYSTEM_FIRST], check=True)

--- a/libs/libcommon/tests/test_ssrf.py
+++ b/libs/libcommon/tests/test_ssrf.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The HuggingFace Authors.
+
+import asyncio
+import socket
+from collections.abc import Iterator
+from contextlib import nullcontext as does_not_raise
+from typing import Any
+
+import aiohttp
+import aiohttp.client
+import httpx
+import pytest
+from huggingface_hub import set_client_factory
+from huggingface_hub.utils._http import default_client_factory
+from pytest import MonkeyPatch
+
+from libcommon.ssrf import (
+    BlockedAddressError,
+    GuardedHTTPTransport,
+    GuardedNetworkBackend,
+    GuardedTCPConnector,
+    guard_httpx_client,
+    guarded_socket_factory,
+    install_ssrf_guard,
+    is_blocked_address,
+    raise_if_blocked_url,
+)
+
+# the hosts the fake resolver knows about, so that the tests don't depend on DNS
+RESOLVED_HOSTS = {
+    "public.example": "93.184.216.34",
+    "metadata.example": "169.254.169.254",  # a host that resolves to an internal address
+    "intranet.example": "10.0.0.1",
+    "loopback.example": "127.0.0.1",
+}
+
+
+@pytest.fixture
+def fake_dns(monkeypatch: MonkeyPatch) -> Iterator[None]:
+    real_getaddrinfo = socket.getaddrinfo
+
+    def getaddrinfo(host: str, port: Any, *args: Any, **kwargs: Any) -> Any:
+        if host in RESOLVED_HOSTS:
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (RESOLVED_HOSTS[host], port or 0))]
+        return real_getaddrinfo(host, port, *args, **kwargs)
+
+    monkeypatch.setattr(socket, "getaddrinfo", getaddrinfo)
+    yield
+
+
+@pytest.fixture
+def installed_guard(monkeypatch: MonkeyPatch) -> Iterator[None]:
+    # setting an attribute to its current value records it, so that it is restored on teardown
+    monkeypatch.setattr(aiohttp, "TCPConnector", aiohttp.TCPConnector)
+    monkeypatch.setattr(aiohttp.client, "TCPConnector", aiohttp.client.TCPConnector)
+    install_ssrf_guard()
+    yield
+    set_client_factory(default_client_factory)
+
+
+@pytest.mark.parametrize(
+    "address,blocked",
+    [
+        # the cloud metadata endpoints
+        ("169.254.169.254", True),
+        ("169.254.170.2", True),
+        # loopback
+        ("127.0.0.1", True),
+        ("::1", True),
+        ("::ffff:127.0.0.1", True),
+        # private (RFC 1918)
+        ("10.0.0.1", True),
+        ("172.16.0.1", True),
+        ("192.168.1.1", True),
+        ("::ffff:10.0.0.1", True),
+        # shared address space (CGNAT)
+        ("100.64.0.1", True),
+        # link-local
+        ("169.254.1.1", True),
+        ("fe80::1", True),
+        # unique-local
+        ("fc00::1", True),
+        ("fd00::1", True),
+        # multicast, unspecified and reserved
+        ("224.0.0.1", True),
+        ("0.0.0.0", True),
+        ("240.0.0.1", True),
+        # public
+        ("8.8.8.8", False),
+        ("93.184.216.34", False),
+        ("2606:4700:4700::1111", False),
+        ("::ffff:8.8.8.8", False),
+    ],
+)
+def test_is_blocked_address(address: str, blocked: bool) -> None:
+    assert is_blocked_address(address) is blocked
+
+
+@pytest.mark.parametrize(
+    "url,expectation",
+    [
+        ("http://169.254.169.254/latest/meta-data/", pytest.raises(BlockedAddressError)),
+        ("http://metadata.example/latest/meta-data/", pytest.raises(BlockedAddressError)),
+        ("https://intranet.example/", pytest.raises(BlockedAddressError)),
+        ("https://loopback.example/", pytest.raises(BlockedAddressError)),
+        ("https://public.example/data.csv", does_not_raise()),
+        ("https://93.184.216.34/data.csv", does_not_raise()),
+    ],
+)
+def test_raise_if_blocked_url(url: str, expectation: Any, fake_dns: None) -> None:
+    with expectation:
+        raise_if_blocked_url(url)
+
+
+@pytest.mark.parametrize(
+    "address,expectation",
+    [
+        ("169.254.169.254", pytest.raises(BlockedAddressError)),
+        ("10.0.0.1", pytest.raises(BlockedAddressError)),
+        ("93.184.216.34", does_not_raise()),
+    ],
+)
+def test_guarded_socket_factory(address: str, expectation: Any) -> None:
+    with expectation:
+        # the socket is created, never connected
+        guarded_socket_factory((socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, 443))).close()
+
+
+def resolve_host(host: str, resolved: list[str]) -> list[str]:
+    """Resolve a host with a `GuardedTCPConnector`, `resolved` being the answer of the resolver."""
+
+    async def resolve() -> list[str]:
+        connector = GuardedTCPConnector(use_dns_cache=False)
+
+        async def resolver_resolve(host: str, port: int = 0, family: Any = socket.AF_INET) -> Any:
+            return [
+                {"hostname": host, "host": address, "port": port, "family": family, "proto": 6, "flags": 0}
+                for address in resolved
+            ]
+
+        connector._resolver.resolve = resolver_resolve  # type: ignore[method-assign]
+        try:
+            return [result["host"] for result in await connector._resolve_host(host, 443)]
+        finally:
+            await connector.close()
+
+    return asyncio.run(resolve())
+
+
+def test_guarded_connector_drops_the_blocked_addresses() -> None:
+    assert resolve_host("mixed.example", ["169.254.169.254", "93.184.216.34"]) == ["93.184.216.34"]
+
+
+def test_guarded_connector_refuses_a_host_resolving_only_to_blocked_addresses() -> None:
+    with pytest.raises(BlockedAddressError):
+        resolve_host("metadata.example", ["169.254.169.254", "10.0.0.1"])
+
+
+def test_guarded_connector_refuses_an_address_used_as_a_host() -> None:
+    # `TCPConnector._resolve_host` doesn't call the resolver when the host already is an IP address
+    with pytest.raises(BlockedAddressError):
+        resolve_host("169.254.169.254", [])
+
+
+def test_guarded_httpx_client_refuses_a_redirect_to_an_internal_host(fake_dns: None) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "public.example":
+            return httpx.Response(302, headers={"location": "http://169.254.169.254/latest/meta-data/"})
+        return httpx.Response(200, text="the response of the internal host")
+
+    client = guard_httpx_client(httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True))
+    with client, pytest.raises(BlockedAddressError):
+        client.get("https://public.example/data.csv")
+
+
+def test_guarded_httpx_client_allows_a_public_host(fake_dns: None) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:  # noqa: ARG001
+        return httpx.Response(200, text="the response of the public host")
+
+    client = guard_httpx_client(httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True))
+    with client:
+        assert client.get("https://public.example/data.csv").text == "the response of the public host"
+
+
+@pytest.fixture
+def refuse_to_connect(monkeypatch: MonkeyPatch) -> Iterator[list[Any]]:
+    """Record the addresses `httpcore` opens a connection to, and never open one."""
+    connected: list[Any] = []
+
+    def create_connection(address: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+        connected.append(address)
+        raise AssertionError(f"connected to {address}")
+
+    monkeypatch.setattr(socket, "create_connection", create_connection)
+    yield connected
+
+
+def rebinding_dns(monkeypatch: MonkeyPatch, host: str, addresses: list[str]) -> None:
+    """Resolve `host` to the next address on each call, to reproduce DNS rebinding."""
+    remaining = list(addresses)
+
+    def getaddrinfo(hostname: str, port: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+        address = remaining.pop(0) if hostname == host and remaining else addresses[-1]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port or 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", getaddrinfo)
+
+
+def test_guarded_network_backend_connects_to_the_address_it_checked(fake_dns: None, monkeypatch: MonkeyPatch) -> None:
+    connected: list[Any] = []
+
+    def create_connection(address: Any, *args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+        connected.append(address)
+        return socket.socket()
+
+    monkeypatch.setattr(socket, "create_connection", create_connection)
+    GuardedNetworkBackend().connect_tcp("public.example", 443).close()
+    # the checked address is connected to, not the host: it cannot resolve to something else in between
+    assert connected == [("93.184.216.34", 443)]
+
+
+def test_guarded_network_backend_refuses_an_internal_host(fake_dns: None, refuse_to_connect: list[Any]) -> None:
+    with pytest.raises(BlockedAddressError):
+        GuardedNetworkBackend().connect_tcp("metadata.example", 80)
+    assert refuse_to_connect == []
+
+
+def test_guarded_httpx_client_refuses_a_host_that_rebinds_after_the_check(
+    monkeypatch: MonkeyPatch, refuse_to_connect: list[Any]
+) -> None:
+    # the pre-flight check gets a public address, the connection would get an internal one
+    rebinding_dns(monkeypatch, "rebinding.example", ["93.184.216.34", "169.254.169.254"])
+
+    client = guard_httpx_client(httpx.Client(transport=GuardedHTTPTransport()))
+    with client, pytest.raises(BlockedAddressError):
+        client.get("http://rebinding.example/latest/meta-data/")
+
+    # the pre-flight check passed on the first answer, so the transport is what refused the second
+    assert refuse_to_connect == []
+
+
+def test_install_ssrf_guard(installed_guard: None) -> None:
+    assert aiohttp.TCPConnector is GuardedTCPConnector
+    assert aiohttp.client.TCPConnector is GuardedTCPConnector
+
+    async def get(url: str) -> Any:
+        async with aiohttp.ClientSession() as session:
+            try:
+                await session.get(url, timeout=aiohttp.ClientTimeout(total=5))
+            except Exception as err:
+                return err.__cause__
+        return None
+
+    # a session built from the defaults, as `fsspec` builds it, refuses an internal address
+    assert isinstance(asyncio.run(get("http://169.254.169.254/latest/meta-data/")), BlockedAddressError)

--- a/services/worker/src/worker/__init__.py
+++ b/services/worker/src/worker/__init__.py
@@ -2,7 +2,12 @@
 # Copyright 2022 The HuggingFace Authors.
 
 from datasets import config as _datasets_config
+from libcommon.ssrf import install_ssrf_guard as _install_ssrf_guard
 
 # This is just to make `datasets` faster:
 # no need to check for a Parquet export since we will build it
 _datasets_config.USE_PARQUET_EXPORT = False
+
+# The worker fetches URLs that come from dataset content, so it must never be able to reach an
+# internal address. Installed here to be sure it is done before the first request.
+_install_ssrf_guard()

--- a/services/worker/src/worker/job_runners/config/parquet_and_info.py
+++ b/services/worker/src/worker/job_runners/config/parquet_and_info.py
@@ -95,6 +95,10 @@ from worker.utils import (
 )
 
 DATASET_TYPE = "dataset"
+# the protocols a data file may be fetched from: the Hub, and the local filesystem for the files the
+# conversion itself downloaded or extracted. Any other protocol is a request to a host the dataset
+# chooses, which is what must not happen.
+NON_REMOTE_PROTOCOLS = frozenset({"", "hf", "file", "local"})
 MAX_FILES_PER_DIRECTORY = 10_000  # hf hub limitation
 MAX_FILES_PER_REPOSITORY = 1_000_000  # hf hub limitation (actually it is 100k but some repos have more)
 MAX_OPERATIONS_PER_COMMIT = 500
@@ -901,6 +905,12 @@ def get_total_files_size(urlpaths: list[str], storage_options: dict[str, Any]) -
         )
     # for other files we simply use fsspec
     external_paths = [path for path in urlpaths if not path.startswith("hf://")]
+    for path in external_paths:
+        # only the last hop of a path with hops, e.g. "zip://data.csv::file:///tmp/data.zip", is fetched
+        last_hop = path.split("::")[-1]
+        protocol = last_hop.split("://")[0] if "://" in last_hop else ""
+        if protocol not in NON_REMOTE_PROTOCOLS:
+            raise ValueError(f"Data file is neither on the Hub nor local: {path}")
     total_size += sum(
         size
         for size in thread_map(

--- a/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
+++ b/services/worker/src/worker/job_runners/dataset/compatible_libraries.py
@@ -17,7 +17,6 @@ from datasets.data_files import (
     DataFilesDict,
     DataFilesPatternsDict,
     DataFilesPatternsList,
-    resolve_pattern,
 )
 from datasets.load import (
     create_builder_configs_from_metadata_configs,
@@ -48,6 +47,7 @@ from worker.dtos import (
     LoadingCode,
 )
 from worker.job_runners.dataset.dataset_job_runner import DatasetJobRunnerWithDatasetsCache
+from worker.utils import allow_only_relative_data_files
 
 try:
     from libviewer._internal import is_optimized_parquet_from_hub
@@ -121,41 +121,42 @@ def get_builder_configs(
         pass
     metadata_configs = MetadataConfigs.from_dataset_card_data(dataset_card_data)
     module_path, _ = _PACKAGED_DATASETS_MODULES[module_name]
-    builder_configs, _ = create_builder_configs_from_metadata_configs(
-        module_path,
-        metadata_configs or MetadataConfigs({"default": {}}),
-        base_path=base_path,
-        download_config=download_config,
-        # No need for default_builder_kwargs since we just need the builder config for the data files
-        # default_builder_kwargs=default_builder_kwargs,
-    )
-    for config in builder_configs:
-        data_files = config.data_files.resolve(base_path=base_path, download_config=download_config)
-        if with_simplified_data_files:
-            config.data_files = DataFilesPatternsDict(
-                {
-                    str(split): (
-                        simplify_data_files_patterns(
-                            data_files_patterns=config.data_files[split],
-                            base_path=base_path,
-                            download_config=download_config,
-                            allowed_extensions=_MODULE_TO_EXTENSIONS[module_name],
+    with allow_only_relative_data_files():
+        builder_configs, _ = create_builder_configs_from_metadata_configs(
+            module_path,
+            metadata_configs or MetadataConfigs({"default": {}}),
+            base_path=base_path,
+            download_config=download_config,
+            # No need for default_builder_kwargs since we just need the builder config for the data files
+            # default_builder_kwargs=default_builder_kwargs,
+        )
+        for config in builder_configs:
+            data_files = config.data_files.resolve(base_path=base_path, download_config=download_config)
+            if with_simplified_data_files:
+                config.data_files = DataFilesPatternsDict(
+                    {
+                        str(split): (
+                            simplify_data_files_patterns(
+                                data_files_patterns=config.data_files[split],
+                                base_path=base_path,
+                                download_config=download_config,
+                                allowed_extensions=_MODULE_TO_EXTENSIONS[module_name],
+                            )
                         )
-                    )
-                    for split in data_files
-                }
-            )
-        else:
-            config.data_files = DataFilesDict.from_patterns(
-                config.data_files,
-                base_path=base_path,
-                download_config=download_config,
-                allowed_extensions=_ALL_ALLOWED_EXTENSIONS,
-            )
-            config.data_files = data_files.filter(
-                extensions=_MODULE_TO_EXTENSIONS[module_name] + _MODULE_TO_METADATA_EXTENSIONS[module_name],
-                file_names=_MODULE_TO_METADATA_FILE_NAMES[module_name],
-            )
+                        for split in data_files
+                    }
+                )
+            else:
+                config.data_files = DataFilesDict.from_patterns(
+                    config.data_files,
+                    base_path=base_path,
+                    download_config=download_config,
+                    allowed_extensions=_ALL_ALLOWED_EXTENSIONS,
+                )
+                config.data_files = data_files.filter(
+                    extensions=_MODULE_TO_EXTENSIONS[module_name] + _MODULE_TO_METADATA_EXTENSIONS[module_name],
+                    file_names=_MODULE_TO_METADATA_FILE_NAMES[module_name],
+                )
     return builder_configs
 
 
@@ -189,7 +190,7 @@ def simplify_data_files_patterns(
         if pattern == "**":
             pattern = "**/*"
         try:
-            resolved_data_files = resolve_pattern(
+            resolved_data_files = datasets.data_files.resolve_pattern(
                 pattern, base_path=base_path, download_config=download_config, allowed_extensions=allowed_extensions
             )
         except FileNotFoundError:
@@ -203,7 +204,7 @@ def simplify_data_files_patterns(
                 new_pattern = pattern.replace("[0-9]" * 5 + "*", "*")
                 new_pattern = new_pattern.replace("[0-9]" * 5, "*")
                 try:
-                    re_resolved_data_files = resolve_pattern(
+                    re_resolved_data_files = datasets.data_files.resolve_pattern(
                         new_pattern,
                         base_path=base_path,
                         download_config=download_config,
@@ -228,7 +229,7 @@ def simplify_data_files_patterns(
                             non_word_char = "[0-9]"
                         new_pattern = new_pattern.replace(NON_WORD_GLOB_SEPARATOR, non_word_char, 1)
                     try:
-                        re_resolved_data_files = resolve_pattern(
+                        re_resolved_data_files = datasets.data_files.resolve_pattern(
                             new_pattern,
                             base_path=base_path,
                             download_config=download_config,
@@ -250,7 +251,7 @@ def simplify_data_files_patterns(
                 elif new_pattern.endswith("*"):
                     new_pattern = new_pattern + allowed_extension
                 try:
-                    re_resolved_data_files = resolve_pattern(
+                    re_resolved_data_files = datasets.data_files.resolve_pattern(
                         new_pattern,
                         base_path=base_path,
                         download_config=download_config,
@@ -259,7 +260,7 @@ def simplify_data_files_patterns(
                     # try again by adding a possible compression extension
                     new_pattern += "." + resolved_data_files[0].split(".")[-1]
                     try:
-                        re_resolved_data_files = resolve_pattern(
+                        re_resolved_data_files = datasets.data_files.resolve_pattern(
                             new_pattern,
                             base_path=base_path,
                             download_config=download_config,

--- a/services/worker/src/worker/job_runners/dataset/init.py
+++ b/services/worker/src/worker/job_runners/dataset/init.py
@@ -36,7 +36,7 @@ from worker.job_runners.dataset.config_names import DatasetConfigNamesJobRunner
 from worker.job_runners.dataset.dataset_job_runner import (
     DatasetJobRunnerWithDatasetsCache,
 )
-from worker.utils import resolve_hf_path
+from worker.utils import allow_only_relative_data_files, resolve_hf_path
 
 
 def compute_init_responses(
@@ -72,7 +72,8 @@ def compute_init_responses(
     repo_dir = f"hf://datasets/{dataset}"
     dataset_init_response: DatasetInitResponse = {"successes": [], "failed": []}
     try:
-        dataset_module = dataset_module_factory(dataset, token=hf_token)
+        with allow_only_relative_data_files():
+            dataset_module = dataset_module_factory(dataset, token=hf_token)
     except _EmptyDatasetError as err:
         raise EmptyDatasetError("The dataset is empty.", cause=err) from err
     except _DataFilesNotFoundError as err:

--- a/services/worker/src/worker/utils.py
+++ b/services/worker/src/worker/utils.py
@@ -6,7 +6,7 @@ import logging
 import os
 import posixpath
 from collections.abc import Iterable, Iterator
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from functools import partial
@@ -29,6 +29,7 @@ from datasets import (
     Json,
     load_dataset,
 )
+from datasets.data_files import resolve_pattern
 from datasets.features.features import decode_nested_example
 from datasets.utils.file_utils import SINGLE_FILE_COMPRESSION_EXTENSION_TO_PROTOCOL, is_relative_path
 from huggingface_hub import HfFileSystem, HfFileSystemFile
@@ -100,6 +101,36 @@ class check_paths_during_decoding:
         traceback: Optional[TracebackType],
     ) -> None:
         return self.exit_stack.close()
+
+
+def _patched_resolve_pattern(
+    pattern: str,
+    base_path: str,
+    allowed_extensions: Optional[list[str]] = None,
+    download_config: Optional[DownloadConfig] = None,
+) -> list[str]:
+    if not is_relative_path(pattern):
+        raise ValueError(f"Data files don't belong to {base_path}")
+    resolved: list[str] = resolve_pattern(
+        pattern, base_path=base_path, allowed_extensions=allowed_extensions, download_config=download_config
+    )
+    return resolved
+
+
+@contextmanager
+def allow_only_relative_data_files() -> Iterator[None]:
+    """Refuse the data files patterns that point outside of the dataset repository.
+
+    `resolve_pattern` is where `datasets` sends the request that resolves a pattern, and the checks
+    on the resolved data files only run once the dataset module is built, i.e. once the request has
+    been sent. A pattern that is not relative to the repository is therefore refused here, before
+    any request.
+
+    `resolve_pattern` also sends a request through `huggingface_hub` before it looks the protocol up
+    in fsspec, so the fsspec allow-list does not cover it either.
+    """
+    with patch("datasets.data_files.resolve_pattern", _patched_resolve_pattern):
+        yield
 
 
 @retry(on=[ConnectionError])
@@ -383,11 +414,12 @@ def safe_load_dataset_builder(
         download_config.token = token
     repo_dir = f"hf://datasets/{path}"
 
-    dataset_module = dataset_module_factory(
-        repo_dir,
-        revision=revision,
-        download_config=download_config,
-    )
+    with allow_only_relative_data_files():
+        dataset_module = dataset_module_factory(
+            repo_dir,
+            revision=revision,
+            download_config=download_config,
+        )
     # Get dataset builder class
     repo_dir_with_commit_hash = repo_dir + f"@{dataset_module.hash}"
     builder_kwargs = dataset_module.builder_kwargs

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -41,6 +41,7 @@ from worker.job_runners.config.parquet_and_info import (
     disallow_embed_local_files,
     fill_builder_info,
     get_delete_operations,
+    get_total_files_size,
     get_urlpaths_in_gen_kwargs,
     get_writer_batch_size_from_info,
     limit_parquet_writes,
@@ -729,6 +730,31 @@ def test_get_urlpaths_in_gen_kwargs(
     tmpfs.put(zip_file, "data.zip")
     tmpfs.put(tar_file, "data.tar")
     assert sorted(get_urlpaths_in_gen_kwargs(gen_kwargs)) == sorted(expected)
+
+
+@pytest.mark.parametrize(
+    "urlpath",
+    [
+        "http://169.254.169.254/latest/meta-data/",
+        "https://example.org/data.csv",
+        "s3://bucket/data.csv",
+        "zip://data.csv::https://example.org/data.zip",
+    ],
+)
+def test_get_total_files_size_refuses_a_remote_urlpath(urlpath: str) -> None:
+    with pytest.raises(ValueError, match="Data file is neither on the Hub nor local"):
+        get_total_files_size([urlpath], storage_options={"hf": {"token": None, "endpoint": CI_HUB_ENDPOINT}})
+
+
+@pytest.mark.parametrize("with_protocol", [True, False])
+def test_get_total_files_size_allows_a_local_urlpath(with_protocol: bool, tmp_path: Path) -> None:
+    # the data files the conversion downloaded or extracted itself are local, and are read from there
+    local_file = tmp_path / "dataset.csv"
+    content = "text\nhello\n"
+    local_file.write_text(content)
+    urlpath = f"file://{local_file}" if with_protocol else str(local_file)
+    size = get_total_files_size([urlpath], storage_options={"hf": {"token": None, "endpoint": CI_HUB_ENDPOINT}})
+    assert size == len(content)
 
 
 def test_stream_convert_to_parquet_estimate_info(tmp_path: Path, csv_path: str) -> None:

--- a/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
+++ b/services/worker/tests/job_runners/dataset/test_compatible_libraries.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import datasets.data_files
 import fsspec
 import numpy as np
 import pyarrow as pa
@@ -861,3 +862,33 @@ def test_is_optimized_parquet_with_real_cdc_file(tmp_path: Path) -> None:
 
     except ImportError:
         pass
+
+
+def test_get_builder_configs_guards_the_data_files_resolution() -> None:
+    class RepoWithoutCardFileSystem:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def exists(self, path: str, **kwargs: Any) -> bool:  # noqa: ARG002
+            return False
+
+        def read_text(self, path: str, **kwargs: Any) -> str:  # noqa: ARG002
+            raise FileNotFoundError(path)
+
+    def create_builder_configs_from_metadata_configs(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+        # `datasets` resolves the data files patterns from here on, and resolving is what sends the
+        # request, so the guard has to be active by now
+        with pytest.raises(ValueError, match="Data files don't belong to"):
+            datasets.data_files.resolve_pattern(
+                "https://example.org/data.csv", base_path="hf://datasets/namespace/dataset@revision"
+            )
+        return [], None
+
+    with (
+        patch("worker.job_runners.dataset.compatible_libraries.HfFileSystem", RepoWithoutCardFileSystem),
+        patch(
+            "worker.job_runners.dataset.compatible_libraries.create_builder_configs_from_metadata_configs",
+            create_builder_configs_from_metadata_configs,
+        ),
+    ):
+        assert get_builder_configs("namespace/dataset", module_name="csv") == []

--- a/services/worker/tests/test_statistics_utils.py
+++ b/services/worker/tests/test_statistics_utils.py
@@ -3,6 +3,7 @@
 import datetime
 from collections.abc import Mapping
 from typing import Any, Optional, Union
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -27,6 +28,7 @@ from libcommon.statistics_utils import (
     ImageColumn,
     IntColumn,
     ListColumn,
+    MediaColumn,
     StringColumn,
     VideoColumn,
     generate_bins,
@@ -630,3 +632,27 @@ def test_datetime_statistics(
     else:
         assert computed_std == expected_std
     assert computed == expected
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "http://169.254.169.254/latest/meta-data/",
+        "https://example.org/audio.mp3",
+        "s3://bucket/audio.mp3",
+        "/etc/passwd",
+    ],
+)
+def test_media_column_open_refuses_a_path_outside_of_the_hub(path: str) -> None:
+    with patch("libcommon.statistics_utils.xopen") as xopen:
+        with pytest.raises(ValueError, match="Media file doesn't belong to the Hub"):
+            MediaColumn.open({"bytes": None, "path": path}, hf_token=None)
+    # `xopen` sends a request before it looks the protocol up, so it must not even be reached
+    xopen.assert_not_called()
+
+
+def test_media_column_open_allows_a_hub_path() -> None:
+    path = "hf://datasets/namespace/dataset@revision/audio.mp3"
+    with patch("libcommon.statistics_utils.xopen") as xopen:
+        MediaColumn.open({"bytes": None, "path": path}, hf_token=None)
+    assert xopen.call_args.args[0] == path

--- a/services/worker/tests/test_utils.py
+++ b/services/worker/tests/test_utils.py
@@ -4,11 +4,13 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import datasets.data_files
 import pytest
 from datasets.packaged_modules.csv.csv import Csv
 
 from worker.utils import (
     FileExtension,
+    allow_only_relative_data_files,
     get_file_extension,
     safe_load_dataset_builder,
 )
@@ -80,3 +82,59 @@ def test_safe_load_dataset_builder_allows_non_arrow_builder() -> None:
         )
 
     assert isinstance(builder, CsvBuilder)
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "http://169.254.169.254/latest/meta-data/",
+        "https://example.org/data.csv",
+        "s3://bucket/data.csv",
+        "/etc/passwd",
+    ],
+)
+def test_allow_only_relative_data_files_refuses_a_pattern_outside_of_the_repository(pattern: str) -> None:
+    with patch("worker.utils.resolve_pattern") as resolver, allow_only_relative_data_files():
+        with pytest.raises(ValueError, match="Data files don't belong to"):
+            datasets.data_files.resolve_pattern(pattern, base_path="hf://datasets/namespace/dataset@revision")
+    # `resolve_pattern` sends a request before it looks the protocol up, so it must not be reached
+    resolver.assert_not_called()
+
+
+def test_safe_load_dataset_builder_guards_the_data_files_resolution() -> None:
+    class CsvBuilder(Csv):  # type: ignore[misc]
+        builder_configs = {"default": SimpleNamespace(data_files=None)}
+
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+    def dataset_module_factory(*args: object, **kwargs: object) -> SimpleNamespace:  # noqa: ARG001
+        # `datasets` resolves the data files patterns from here, and resolving is what sends the
+        # request, so the guard has to be active by now. This covers every job runner that reaches
+        # `dataset_module_factory` through `safe_load_dataset_builder`: config-split-names,
+        # split-first-rows and config-parquet-and-info.
+        with pytest.raises(ValueError, match="Data files don't belong to"):
+            datasets.data_files.resolve_pattern(
+                "https://example.org/data.csv", base_path="hf://datasets/namespace/dataset@revision"
+            )
+        return _get_dataset_module()
+
+    with (
+        patch("datasets.load.dataset_module_factory", dataset_module_factory),
+        patch("datasets.load.get_dataset_builder_class", return_value=CsvBuilder),
+    ):
+        builder = safe_load_dataset_builder(
+            path="namespace/dataset", name="default", data_files=None, download_mode=None
+        )
+
+    assert isinstance(builder, CsvBuilder)
+
+
+def test_allow_only_relative_data_files_allows_a_relative_pattern() -> None:
+    resolved = ["hf://datasets/namespace/dataset@revision/data/train.csv"]
+    with allow_only_relative_data_files(), patch("worker.utils.resolve_pattern", return_value=resolved) as resolver:
+        assert (
+            datasets.data_files.resolve_pattern("data/*.csv", base_path="hf://datasets/namespace/dataset@revision")
+            == resolved
+        )
+    resolver.assert_called_once()


### PR DESCRIPTION
## The vulnerability

`datasets` sends a HEAD request through `huggingface_hub` (httpx) from `_prepare_path_and_storage_options` for any URL containing the substring `drive.google.com` — which a query string satisfies. Both `xopen` and `resolve_pattern` call that helper *before* they look the protocol up in fsspec, so the request is sent upstream of the allow-list in `libcommon/fsspec.py`, which never sees it. A dataset can therefore make the worker request an arbitrary host and port from inside the cluster.

Reproduced live from production on `dataset-config-names` (a README-only dataset, first job in the pipeline) and on `split-descriptive-statistics` (attacker URL in Parquet content, so no `data_files` check sees it). Blind SSRF: HEAD only, no read primitive, and the production requests carried no `Authorization` or `Cookie`.

## The fix

| Route | Load-bearing check |
|---|---|
| `dataset-config-names`, `dataset-init`, `config-split-names`, `split-first-rows`, `config-parquet-and-info`, `dataset-compatible-libraries` | `allow_only_relative_data_files()` — refuses a `data_files` pattern that is not relative to the repository, before `resolve_pattern` |
| `split-descriptive-statistics` media | the `hf://` check in `MediaColumn.open`, before `xopen` |
| parquet external-shard probe | the last-hop `hf://` check in `get_total_files_size` |
| fsspec/aiohttp transport | `libcommon/fsspec.py` now evicts the live registry as well as `known_implementations`, so the protocol removal is order-independent (previously a protocol imported before `libcommon` stayed usable — and only under the name it was imported with, so `https` worked while `http` was refused) |
| any transport, any route | `libcommon.ssrf` — refuses non-public addresses (loopback, RFC 1918, CGNAT, link-local, unique-local, multicast, reserved) on both aiohttp (fsspec, s3fs) and httpx (huggingface_hub) |

**The `hf://` path checks — not the fsspec registry eviction — are what close the live routes**, because the HEAD is sent upstream of fsspec entirely. Please don't drop them as redundant with the allow-list; the ordering comments and the `assert_not_called()` assertions in the tests exist to pin that.

## Residual risk

- DNS rebinding is closed on both transports: each connects to an address it has already checked instead of resolving the host again. TLS is unaffected, since `aiohttp` and `httpcore` take the name used for SNI and for the certificate check from the request URL, not from the address connected to.
- An `HTTP(S)_PROXY` in the environment (`trust_env`) routes httpx through `_mounts` and bypasses the guarded transport, so the proxy would be checked rather than the eventual destination. No environment configures one.
- The Rust transports cannot be hooked from Python: `libviewer` (opendal), `hf_xet`, `pylance`, and duckdb's extension installer, which runs `INSTALL 'fts'` before `SET enable_external_access=false`. Their destinations are the HF endpoint or operator configuration.
- The media path check requires `hf://` but is not scoped to the dataset's own repository, so a cross-repo read on the Hub remains possible. That is token scoping, not SSRF.
- The `"drive.google.com"` substring test is an upstream `huggingface_hub`/`datasets` bug (`datasets/utils/file_utils.py:921`): it fires a HEAD at an unvalidated host from a helper that runs before any protocol check, so any future caller of `xopen` or `resolve_pattern` re-inherits it. To be reported through the security process rather than as a public issue.

## Rollback

Removing the `_install_ssrf_guard()` call in `services/worker/src/worker/__init__.py` restores the previous transport behaviour on its own. The path checks and the `fsspec.py` change should not be reverted with it — those are what close the live routes and the allow-list bypass. No migration, no configuration change.
