### PR TITLE
fix(worker): roll worker-light gradually and raise web-app startup timeout

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -545,6 +545,14 @@ workers:
     workerDifficultyMin: 0
     maxMemoryPct: 0
     maxSystemMemoryPct: 0
+    # The small CPU request packs a dozen light workers per node, so recreating them all at
+    # once starves their cold start. Roll gradually instead, and keep maxSurge at 0 so the
+    # pool still never exceeds its replica count while rolling, as Recreate guaranteed.
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 0
+        maxUnavailable: 25%
     # Increased probe timeouts for light workers due to limited resources
     startupProbe:
       failureThreshold: 120

--- a/chart/templates/worker/_deployment.yaml
+++ b/chart/templates/worker/_deployment.yaml
@@ -22,7 +22,11 @@ spec:
   selector:
     matchLabels: {{ include "labels.worker" (merge (dict "workerValues" .workerValues) $ ) | nindent 6 }}
   strategy:
+    {{- if .workerValues.strategy }}
+    {{- toYaml .workerValues.strategy | nindent 4 }}
+    {{- else }}
     type: Recreate
+    {{- end }}
   template:
     metadata:
       labels: {{ include "labels.worker" (merge (dict "workerValues" .workerValues) $ ) | nindent 8 }}

--- a/services/worker/src/worker/executor.py
+++ b/services/worker/src/worker/executor.py
@@ -26,6 +26,11 @@ from worker.loop import WorkerState
 START_WORKER_LOOP_PATH = start_worker_loop.__file__
 START_WEB_APP_PATH = start_web_app.__file__
 
+# Seconds to wait for the web app to accept connections. It has to cover a cold start on a
+# CPU-throttled worker, where the imports alone can take tens of seconds: timing out here
+# exits the container, so a value that is too low turns a slow start into a crash loop.
+WEB_APP_STARTUP_TIMEOUT_SECONDS = 60
+
 
 async def every(
     func: Callable[..., Optional[Any]],
@@ -85,7 +90,12 @@ class WorkerExecutor:
         logging.info("Starting webapp for /healthcheck and /metrics.")
         start_web_app_command = [sys.executable, START_WEB_APP_PATH]
         uvicorn_config = UvicornConfig.from_env()
-        return TCPExecutor(start_web_app_command, host=uvicorn_config.hostname, port=uvicorn_config.port, timeout=10)
+        return TCPExecutor(
+            start_web_app_command,
+            host=uvicorn_config.hostname,
+            port=uvicorn_config.port,
+            timeout=WEB_APP_STARTUP_TIMEOUT_SECONDS,
+        )
 
     def start(self) -> None:
         if self.executors:


### PR DESCRIPTION
Follow-up to #3402 (deny-all egress NetworkPolicy for the workers). The `worker-light` crashloop seen during that rollout was **not** caused by the egress policy — it is a pre-existing cold-start problem that any rollout of that pool triggers. This PR fixes it.

## Root cause

`worker-light` requests only `200m` CPU (limit `2`, `chart/env/prod.yaml`), so the scheduler packs a dozen or more light pods onto each node. The pool's Deployment used `strategy: Recreate`, which kills every replica and recreates them all simultaneously — so on any rollout, all of a node's light pods cold-start at the same moment.

Worker startup is import-heavy (torch, pymupdf, duckdb, polars under py3.14). With only 200m guaranteed CPU and a dozen peers competing for the same cores, the worker's local web app (`start_web_app.py`, serving `/healthcheck` and `/metrics`) needs more than 10 seconds to bind its port. The `mirakuru` `TCPExecutor` that supervises it gave up at 10s, which propagates out of `WorkerExecutor.start()` and exits the process:

```
worker/main.py
  -> worker/executor.py: web_app_executor.start()
    -> mirakuru.tcp.TCPExecutor "start_web_app.py"
      -> TimeoutExpired: timed out after 10 seconds
```

The container then exits 1 and enters `CrashLoopBackOff`, and only recovers once backoff has staggered the restarts enough for the survivors to get CPU.

`worker-medium` (1200m) and `worker-heavy` (8 CPU) never hit this: their large CPU requests make the scheduler place them sparsely, so few pods on a node ever cold-start together.

## Changes

**1. `worker-light` rolls gradually instead of all at once.** The `strategy` was hardcoded in the shared worker Deployment template, so this adds a per-pool `strategy` override that defaults to the existing `Recreate`. Only `worker-light` sets it:

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxSurge: 0
    maxUnavailable: 25%
```

`maxSurge: 0` keeps the property `Recreate` implied — the pool never exceeds its replica count while rolling, so a roll cannot over-provision workers. `maxUnavailable: 25%` replaces the herd with four gradual waves, so the pods that come up have CPU to start with. `worker-medium`, `worker-heavy` and `worker-all` are untouched and still render `Recreate`; they could benefit from the same treatment later, but that is deliberately out of scope here.

There was no comment in the chart explaining the original `Recreate` choice — it dates back to #679 (`add /sizes`) with no stated rationale — so nothing to preserve. A comment now records why `worker-light` differs.

**2. Web-app startup timeout 10s -> 60s.** `_create_web_app_executor()` passed an explicit `timeout=10` (which happened to equal mirakuru's default). It is now a named constant at 60s, matching the `timeout=60` the sibling worker-loop executor already uses. This is the safety net: even with a gradual roll, a cold start that is merely slow should not exit the container. The timeout only bounds startup, so raising it does not delay steady-state failure detection — a web app that dies later is caught by the `ensure_webapp` loop, which restarts it every 10s as before.

Staging's `worker-light` is intentionally left on `Recreate`: it caps at 5 replicas with a 100m request, so it does not produce the packing that causes the herd. Say the word if you'd rather have staging parity first.

## Validation

- `helm template` of the prod values renders exactly one difference against `main` — `worker-light`'s `strategy` block. `worker-heavy`, `worker-medium` still render `type: Recreate`.
- `helm template` of the staging values and of the default values is **byte-identical** to `main`, confirming the new override defaults to current behavior.
- `helm lint` passes for default, staging and prod values.
- `ruff check src` and `ruff format --check src` pass on `services/worker` (pinned 0.15.17); `mypy --strict` reports no issues on the touched file.
