### PR TITLE
fix(libcommon): force root logging config so worker INFO logs are not dropped

### DIFF
--- a/libs/libcommon/src/libcommon/log.py
+++ b/libs/libcommon/src/libcommon/log.py
@@ -5,5 +5,8 @@ import logging
 
 
 def init_logging(level: int = logging.INFO) -> None:
-    logging.basicConfig(level=level, format="%(levelname)s: %(asctime)s - %(name)s - %(message).5000s")
+    # force=True: heavy imports (datasets, torch, ...) can attach a handler to the root logger before
+    # this runs, which would make basicConfig a no-op and leave the root logger at its default WARNING
+    # level, silently dropping every root INFO/DEBUG log. force removes those handlers and applies ours.
+    logging.basicConfig(level=level, format="%(levelname)s: %(asctime)s - %(name)s - %(message).5000s", force=True)
     logging.debug(f"Log level set to: {logging.getLevelName(logging.getLogger().getEffectiveLevel())}")

--- a/libs/libcommon/tests/test_log.py
+++ b/libs/libcommon/tests/test_log.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The HuggingFace Authors.
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from libcommon.log import init_logging
+
+
+@pytest.fixture
+def preserve_root_logging() -> Iterator[None]:
+    root = logging.getLogger()
+    handlers = root.handlers[:]
+    level = root.level
+    try:
+        yield
+    finally:
+        root.handlers[:] = handlers
+        root.setLevel(level)
+
+
+def test_init_logging_overrides_a_preexisting_root_handler(preserve_root_logging: None) -> None:
+    # A dependency imported before init_logging() (datasets, torch, ...) may already have attached a
+    # handler to the root logger. Without force=True, logging.basicConfig() is then a no-op, the root
+    # logger stays at its default WARNING level, and every root INFO/DEBUG log is silently dropped.
+    root = logging.getLogger()
+    root.handlers[:] = [logging.NullHandler()]
+    root.setLevel(logging.WARNING)
+
+    init_logging(level=logging.INFO)
+
+    assert root.getEffectiveLevel() == logging.INFO
+    assert root.isEnabledFor(logging.INFO)


### PR DESCRIPTION
## The bug

Root-logger `logging.info(...)` / `logging.debug(...)` calls in the worker never appear — not even in the container stdout (so it is not a Filebeat/shipping issue). Example: `logging.info("Worker loop started")` in `services/worker/src/worker/loop.py` is never logged.

## Cause

`init_logging()` calls `logging.basicConfig(...)` **without `force=True`**. `logging.basicConfig` is a no-op when the root logger already has a handler. In the worker loop process, `init_logging()` runs *after* the heavy imports at the top of `start_worker_loop.py` (`worker.loop`, `worker.resources` → `datasets`, `worker.job_runner_factory` → the job runners → torch/pymupdf/duckdb/polars/numba …). One of those imports attaches a handler to the root logger at import time, so `basicConfig` does nothing: the root logger keeps its default `WARNING` level and default format.

Result: every root `INFO`/`DEBUG` log in the worker (and the executor) is silently dropped, while `WARNING`/`ERROR` still surface in the default `LEVEL:root:message` format (e.g. `ERROR:root:Executor received SIGTERM`, note the default format rather than `init_logging`'s). The web-app subprocess is unaffected because it does not call `init_logging` — its logging is configured by uvicorn.

## Fix

Pass `force=True` to `basicConfig` so `init_logging()` is authoritative: it removes any handler a prior import attached to the root logger and installs ours at the configured level. One line, and it fixes every service that calls `init_logging`, not just the worker loop.

Added `libs/libcommon/tests/test_log.py`: with a handler pre-attached to the root logger and its level at `WARNING`, `init_logging(level=INFO)` must leave the root logger enabled for `INFO` — this fails before the change and passes after.
