### PR TITLE
fix(worker): fix two pre-existing failing tests blocking CI

### DIFF
--- a/services/worker/tests/fixtures/hub.py
+++ b/services/worker/tests/fixtures/hub.py
@@ -801,7 +801,9 @@ PRESIDIO_SCAN_rows = [
 @pytest.fixture
 def hub_responses_does_not_exist() -> HubDatasetTest:
     return {
-        "name": "does_not_exist",
+        # must be a well-formed "namespace/name" repo id: an id without a namespace is rejected as
+        # invalid before any Hub call, so it would not exercise the "does not exist on the Hub" path
+        "name": f"{CI_USER}/does_not_exist",
         "config_names_response": None,
         "splits_response": None,
         "first_rows_response": None,

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -461,14 +461,19 @@ class JobRunnerArgs(TypedDict):
 
 
 def launch_job_runner(job_runner_args: JobRunnerArgs) -> CompleteJobResult:
-    from libcommon.resources import CacheMongoResource
+    from libcommon.resources import CacheMongoResource, QueueMongoResource
 
     config = job_runner_args["config"]
     dataset = job_runner_args["dataset"]
     revision = job_runner_args["revision"]
     app_config = job_runner_args["app_config"]
     tmp_path = job_runner_args["tmp_path"]
-    with CacheMongoResource(database=app_config.cache.mongo_database, host=app_config.cache.mongo_url):
+    # the queue connection is required by the git branch lock, and a pool worker only inherits it
+    # from the parent process when it is forked
+    with (
+        CacheMongoResource(database=app_config.cache.mongo_database, host=app_config.cache.mongo_url),
+        QueueMongoResource(database=app_config.queue.mongo_database, host=app_config.queue.mongo_url),
+    ):
         job_runner = ConfigParquetAndInfoJobRunner(
             job_info=JobInfo(
                 job_id=f"job_{config}",

--- a/services/worker/tests/job_runners/config/test_parquet_and_info.py
+++ b/services/worker/tests/job_runners/config/test_parquet_and_info.py
@@ -52,7 +52,7 @@ from worker.job_runners.config.parquet_and_info import (
 from worker.job_runners.dataset.config_names import DatasetConfigNamesJobRunner
 from worker.resources import LibrariesResource
 
-from ...constants import CI_HUB_ENDPOINT, CI_USER_TOKEN
+from ...constants import CI_HUB_ENDPOINT, CI_URL_TEMPLATE, CI_USER_TOKEN
 from ...fixtures.hub import HubDatasetTest
 from ..utils import REVISION_NAME
 
@@ -496,6 +496,9 @@ def set_hub_ci_env() -> None:
     os.environ["HF_ENDPOINT"] = CI_HUB_ENDPOINT
     datasets.config.HF_ENDPOINT = CI_HUB_ENDPOINT
     huggingface_hub.constants.ENDPOINT = CI_HUB_ENDPOINT
+    # huggingface_hub builds this template from the endpoint at import time, so it still points to
+    # prod in a child process that did not inherit the monkeypatches from `monkeypatch_session`
+    huggingface_hub.constants.HUGGINGFACE_CO_URL_TEMPLATE = CI_URL_TEMPLATE
 
 
 def test_concurrency(


### PR DESCRIPTION
Two tests in `services/worker` have been failing on `main` for a while. They are unrelated to each other and to any pending PR, but because CI runs the whole worker suite they turn every PR red, so they are worth fixing on their own.

Latest `main` run at `1376d89d` ([32035469397](https://github.com/huggingface/dataset-viewer/actions/runs/32035469397)): `2 failed, 446 passed, 1 skipped, 15 deselected`.

```
FAILED tests/job_runners/config/test_split_names.py::test_compute_split_names_from_streaming_response[does_not_exist-False-SplitNamesFromStreamingError-DatasetNotFoundError]
  - AssertionError: assert 'ValueError' == 'DatasetNotFoundError'
FAILED tests/job_runners/config/test_parquet_and_info.py::test_concurrency
  - RuntimeError: Worker 0 (config=config0) failed: The dataset, or the revision, does not exist on the Hub.
```

## 1. `test_compute_split_names_from_streaming_response[does_not_exist]`

**Root cause.** `safe_load_dataset_builder` starts with a guard that rejects anything that is not a well-formed `namespace/name` repo id, before any Hub call:

```python
if path.count("/") != 1 or ".." in path or path.startswith("/"):
    raise ValueError(f"Invalid dataset: {path}")
```

`#3381` wrapped `get_dataset_split_names` in `with safe_inspect:` in `config/split_names.py`, so the guard now applies to that job runner. The `hub_responses_does_not_exist` fixture used the bare id `does_not_exist`, with no namespace, so it trips the guard and the cause becomes `ValueError` instead of the `DatasetNotFoundError` the test expects. The `gated` and `private` rows of the same test still pass because they use real `namespace/name` ids.

**Fix.** Give the fixture a namespaced id (`DVUser/does_not_exist`) rather than relaxing the guard or changing the expectation.

The guard is doing exactly what it was added for in `#3360`: never hand a possibly malformed path to the loader. Rejecting an id with no namespace is correct, and no real dataset id reaches the worker without one, so there is no product bug to fix here — only an unrealistic test input, left over from when namespace-less canonical dataset ids existed. Changing the expectation to `ValueError` would have been smaller, but it would quietly repurpose the row: it is meant to cover "the dataset does not exist on the Hub", and after `#3381` nothing in `config-split-names` covered that path any more. With a namespaced id the request reaches the Hub, 404s, and `datasets` raises `DatasetNotFoundError` as before, so the original assertion holds unchanged.

The fixture is also used by `dataset/config_names.py`'s equivalent test, which expects `RetryableConfigNamesError` / `DatasetNotFoundError` and passes today (that job runner does not use the safe wrapper). It keeps passing: a namespaced missing repo reaches the same `RepositoryNotFoundError` -> `DatasetNotFoundError` mapping.

## 2. `test_concurrency`

**Root cause.** Not related to `#3381`. `set_hub_ci_env`, the `Pool` initializer, re-applies the hub-ci endpoint in the child processes but misses one of the three things `monkeypatch_session` patches: `huggingface_hub.constants.HUGGINGFACE_CO_URL_TEMPLATE`.

`huggingface_hub` builds that template from the endpoint at import time (`constants.py`), and the initializer cannot fix it by setting `HF_ENDPOINT` because the module is already imported by then. So a child that did not inherit the parent's in-memory patches ends up in an inconsistent state: a prod template with `constants.ENDPOINT` pointing at hub-ci. `hf_hub_url` only rewrites the endpoint when the templated URL starts with `constants.ENDPOINT`:

```python
url = constants.HUGGINGFACE_CO_URL_TEMPLATE.format(...)
if endpoint is not None and url.startswith(constants.ENDPOINT):
    url = endpoint + url[len(constants.ENDPOINT):]
```

With a prod template that test is false, the rewrite is skipped, and the children resolve `README.md` against prod, where the test repo does not exist. `datasets` turns the resulting `RepositoryNotFoundError` into `DatasetNotFoundError`, and `parquet_and_info.py` reports it as "The dataset, or the revision, does not exist on the Hub." Ironically, patching `constants.ENDPOINT` is what breaks it: had both been left at prod, the rewrite would have applied and produced the right URL.

This was invisible while `multiprocessing` defaulted to `fork` and the children inherited the parent's patches. Python 3.14 (`#3358`) changed the default start method to `forkserver` on Linux (gh-84559), which is when the test went red; it also fails locally on macOS, where the default has been `spawn` for much longer. `set_hub_ci_env` was added in `#3346` for that reason, just incompletely.

**Fix, part 1.** Patch the template alongside the endpoint, restoring parity with `monkeypatch_session`, so the initializer no longer depends on the start method.

**Root cause, second layer.** Fixing the endpoint uncovered the next piece of parent state the children no longer inherit, this time the mongoengine connections:

```
RuntimeError: Worker 0 (config=config0) failed: Connection with alias "queue" has not been defined
```

`launch_job_runner` already opens a `CacheMongoResource` in the worker, but never opened a `QueueMongoResource`, so the `queue` alias was only ever present because a forked child inherited the parent's connection. The git branch lock that `create_commits` takes stores its documents in the queue database (`Lock.meta.db_alias`), and taking that lock is the whole point of this test, so it fails immediately.

**Fix, part 2.** Open the queue connection next to the cache one in `launch_job_runner`. That function is already where the worker establishes its own database connections, so the omission was simply hidden by `fork`. It also mirrors libcommon's own `test_lock`, which allocates a `QueueMongoResource` in its pool workers to exercise this same lock.

Both parts are the same underlying bug — a `Pool` worker no longer inherits the parent's in-memory state — so neither is an `xfail`/`skip` candidate: the failure is deterministic, and production is unaffected (the worker always gets a real endpoint from `COMMON_HF_ENDPOINT` and opens its own connections at startup).

## Validation

The worker suite needs a heavy environment (mongo plus hub-ci credentials) that was not available here, so the two tests were not run end to end. Instead:

- CI on this branch has already confirmed fix 1: `test_split_names[does_not_exist]` passes, and the count went from 446 to 447 passed ([run 32039270909](https://github.com/huggingface/dataset-viewer/actions/runs/32039270909)).
- That same run confirmed part 1 of the `test_concurrency` fix, which is what surfaced the second layer described above: the "does not exist on the Hub" failure was replaced by the missing `queue` alias.
- The endpoint mechanism was also reproduced directly against the installed `huggingface_hub` 1.19.0 by simulating the child-process state. Before the fix, `hf_hub_url` returns `https://huggingface.co/datasets/...`; with the template patched it returns `https://hub-ci.huggingface.co/datasets/...`.
- The `datasets` 5.0 code path was read to confirm `RepositoryNotFoundError` -> `DatasetNotFoundError` for a missing namespaced repo, so the restored `does_not_exist` assertion holds.
- `ruff check` (`src` and `tests --ignore=ARG`) and `ruff format --check` pass, using the pinned 0.15.17.
