### PR TITLE
fix(chart): use ip target-type for staging ALB ingresses

### DIFF
--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -169,6 +169,7 @@ ingress:
     alb.ingress.kubernetes.io/healthcheck-path: "/healthcheck"
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80, "HTTPS": 443}]'
     alb.ingress.kubernetes.io/scheme: "internet-facing"
+    alb.ingress.kubernetes.io/target-type: "ip"
     alb.ingress.kubernetes.io/group.name: "datasets-server"
     kubernetes.io/ingress.class: "alb"
     alb.ingress.kubernetes.io/group.order: "100"


### PR DESCRIPTION
Set `alb.ingress.kubernetes.io/target-type: ip` on the shared staging ingress annotations, so the ALB registers pod IPs directly instead of instance / NodePort targets.

With the default `instance` target-type, every node in the cluster is registered as a target on the service NodePort. Targeting pod IPs directly is more precise, and is already the pattern used for some prod ingresses.
