### PR TITLE
install fts in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN poetry install --no-cache
 # Install libviewer wheel built in the viewer stage
 COPY --from=viewer /tmp/dist /tmp/dist
 RUN pip install /tmp/dist/libviewer-*.whl
-RUN duckdb -c "SET extension_directory = '$DUCKDB_INDEX_EXTENSIONS_DIRECTORY'; INSTALL 'fts';"
+RUN python -c "import duckdb; duckdb.execute(\"SET extension_directory = '$DUCKDB_INDEX_EXTENSIONS_DIRECTORY'; INSTALL 'fts';\")"
 CMD ["poetry", "run", "python", "src/search/main.py"]
 
 # SSE API service

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,7 @@ CMD ["poetry", "run", "python", "src/rows/main.py"]
 
 # Search service
 FROM libapi AS search
+ARG DUCKDB_INDEX_EXTENSIONS_DIRECTORY="/tmp/duckdb-extensions"
 COPY services/search /src/services/search
 WORKDIR /src/services/search
 RUN poetry install --no-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,7 @@ RUN poetry install --no-cache
 # Install libviewer wheel built in the viewer stage
 COPY --from=viewer /tmp/dist /tmp/dist
 RUN pip install /tmp/dist/libviewer-*.whl
+RUN duckdb -c "SET extension_directory = '$DUCKDB_INDEX_EXTENSIONS_DIRECTORY'; INSTALL 'fts';"
 CMD ["poetry", "run", "python", "src/search/main.py"]
 
 # SSE API service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,8 @@ services:
   search:
     build:
       target: search
+      args:
+        - DUCKDB_INDEX_EXTENSIONS_DIRECTORY=$DUCKDB_INDEX_EXTENSIONS_DIRECTORY
     volumes:
       - storage:${STORAGE_DIRECTORY}
       - parquet-metadata:${PARQUET_METADATA_STORAGE_DIRECTORY}:rw

--- a/libs/libcommon/src/libcommon/duckdb_utils.py
+++ b/libs/libcommon/src/libcommon/duckdb_utils.py
@@ -43,7 +43,7 @@ ATTACH_JOB_AGGREGATION_DATABASE = "ATTACH {database} as tmp;"
 ATTACH_READ_ONLY_JOB_AGGREGATION_DATABASE = "ATTACH IF NOT EXISTS {database} as tmp (READ_ONLY);"
 ATTACH_SUBPROCESS_JOB_DATABASE = "ATTACH {database} as tmp_{rank}_{field_id};"
 ATTACH_READ_ONLY_SUBPROCESS_JOB_DATABASE = "ATTACH IF NOT EXISTS {database} as tmp_{rank}_{field_id} (READ_ONLY);"
-LOAD_FTS_COMMAND = "INSTALL 'fts'; LOAD 'fts';"
+LOAD_FTS_COMMAND = "LOAD 'fts';"
 DISABLE_EXTERNAL_ACCESS_COMMAND = "SET enable_external_access=false;"
 SET_ALLOWED_PATHS_COMMAND = "SET allowed_paths={allowed_paths};"
 LOCK_CONFIG_COMMAND = "SET lock_configuration=true;"
@@ -66,7 +66,6 @@ ALTER_TABLE_BY_ADDING_SEQUENCE_COLUMN = (
     f"ALTER TABLE data ADD COLUMN {ROW_IDX_COLUMN} BIGINT DEFAULT nextval('serial');"
 )
 CREATE_INDEX_ID_COLUMN_COMMANDS = CREATE_SEQUENCE_COMMAND + ALTER_TABLE_BY_ADDING_SEQUENCE_COLUMN
-INSTALL_AND_LOAD_EXTENSION_COMMAND = "INSTALL 'fts'; LOAD 'fts';"
 REPO_TYPE = "dataset"
 # Only some languages are supported, see: https://duckdb.org/docs/extensions/full_text_search.html#pragma-create_fts_index
 STEMMER_MAPPING = {


### PR DESCRIPTION
fix this error

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/site-packages/anyio/to_thread.py", line 63, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        func, args, abandon_on_cancel=abandon_on_cancel, limiter=limiter
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/anyio/_backends/_asyncio.py", line 2518, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/anyio/_backends/_asyncio.py", line 1002, in run
    result = context.run(func, *args)
  File "/src/libs/libapi/src/libapi/duckdb.py", line 146, in build_index_file
    with duckdb_connect(
         ~~~~~~~~~~~~~~^
        database=index_file_location,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        transformed_df=transformed_df,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ) as con:
    ^
  File "/src/libs/libcommon/src/libcommon/duckdb_utils.py", line 700, in duckdb_connect
    con.sql(LOAD_FTS_COMMAND)
    ~~~~~~~^^^^^^^^^^^^^^^^^^
_duckdb.IOException: IO Error: Failed to download extension "fts" at URL "http://extensions.duckdb.org/v1.5.5/linux_amd64/fts.duckdb_extension.gz"
Extension "fts" is an existing extension.

For more info, visit https://duckdb.org/docs/stable/extensions/troubleshooting?version=v1.5.5&platform=linux_amd64&extension=fts (ERROR Connection timed out)

```