### PR TITLE
fix(search): restrict the /filter expression grammar

### DIFF
--- a/services/search/src/search/routes/filter.py
+++ b/services/search/src/search/routes/filter.py
@@ -58,28 +58,26 @@ FILTER_COUNT_QUERY = """\
 SQL_INVALID_SYMBOLS = "|".join([";", "--", r"/\*", r"\*/"])
 SQL_INVALID_SYMBOLS_PATTERN = re.compile(rf"(?:{SQL_INVALID_SYMBOLS})", flags=re.IGNORECASE)
 
-SQL_MATCH_NUMBER = r"[0-9][0-9\.]*"
+SQL_MATCH_NUMBER = r"[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)"
 SQL_MATCH_VARCHAR = r"'([^']|'')*'"  # ' is escaped with ''
 SQL_MATCH_KEY = r'"([^"]|"")+"'  # " is escaped with ""
 SQL_MATCH_COL = rf"{SQL_MATCH_KEY}(\.{SQL_MATCH_KEY})*"  # allow sub-columns
 SQL_MATCH_ARGS = f"({SQL_MATCH_NUMBER}|{SQL_MATCH_VARCHAR}|,| )*"
-SQL_MATCH_FUNC = rf"[a-z_]+\({SQL_MATCH_ARGS}\)"
+SQL_MATCH_FUNC = rf"(?:len|length|lower|replace|upper)\({SQL_MATCH_ARGS}\)"
 SQL_MATCH_TRANSFORMED_COL = rf"\(?{SQL_MATCH_COL}\)?(\.{SQL_MATCH_FUNC})?"
-SQL_MATCH_OP = (
-    r"(=|<|>|!|~|\*| |(like)|(ilike)|(glob)|(similar to)|(is)|(not)|(LIKE)|(ILIKE)|(GLOB)|(SIMILAR TO)|(IS)|(NOT))+"
-)
-SQL_MATCH_BOOL_OR_NULL = r"(true|false|null|NULL)"
+SQL_MATCH_OP = r"(?:=|!=|<>|<=|>=|<|>|~|LIKE|ILIKE|GLOB|SIMILAR TO|IS|IS NOT)"
+SQL_MATCH_BOOL_OR_NULL = r"(?:true|false|null)"
 SQL_MATCH_VAL = f"({SQL_MATCH_NUMBER}|{SQL_MATCH_VARCHAR}|{SQL_MATCH_BOOL_OR_NULL})"
-SQL_MATCH_COND = r"(and|or|AND|OR)"
+SQL_MATCH_COND = r"(?:and|or)"
 SQL_MATCH_EXPR = rf"\(?{SQL_MATCH_TRANSFORMED_COL} ?{SQL_MATCH_OP} ?{SQL_MATCH_VAL}\)?"
-SQL_MATCH_DIRECTION = r"(asc|desc|ASC|DESC)"
+SQL_MATCH_DIRECTION = r"(?:asc|desc)"
 
 SQL_MATCH_WHERE = f"^{SQL_MATCH_EXPR}( {SQL_MATCH_COND} {SQL_MATCH_EXPR})*$"
 SQL_MATCH_ORDERBY = f"^{SQL_MATCH_TRANSFORMED_COL}( {SQL_MATCH_DIRECTION})?$"
 
 SQL_PARAMETER_PATTERNS: dict[Literal["where", "orderby"], re.Pattern[str]] = {
-    "where": re.compile(SQL_MATCH_WHERE),
-    "orderby": re.compile(SQL_MATCH_ORDERBY),
+    "where": re.compile(SQL_MATCH_WHERE, flags=re.IGNORECASE),
+    "orderby": re.compile(SQL_MATCH_ORDERBY, flags=re.IGNORECASE),
 }
 
 logger = logging.getLogger(__name__)
@@ -119,7 +117,14 @@ def create_filter_endpoint(
                     offset = get_request_parameter_offset(request)
                     length = get_request_parameter_length(request)
                     logger.info(
-                        f"/filter, {dataset=}, {config=}, {split=}, {where=}, {orderby=}, {offset=}, {length=}"
+                        "/filter, dataset=%s, config=%s, split=%s, where_length=%d, orderby_length=%d, offset=%d, length=%d",
+                        dataset,
+                        config,
+                        split,
+                        len(where),
+                        len(orderby),
+                        offset,
+                        length,
                     )
                 with StepProfiler(method="filter_endpoint", step="check authentication"):
                     # If auth_check fails, it will raise an exception that will be caught below
@@ -271,6 +276,6 @@ def execute_filter_query(
 
 def validate_query_parameter(parameter_value: str, parameter_name: Literal["where", "orderby"]) -> None:
     if SQL_INVALID_SYMBOLS_PATTERN.search(parameter_value) or (
-        parameter_value and not SQL_PARAMETER_PATTERNS[parameter_name].match(parameter_value)
+        parameter_value and not SQL_PARAMETER_PATTERNS[parameter_name].fullmatch(parameter_value)
     ):
         raise InvalidParameterError(message=f"Parameter '{parameter_name}' contains errors or invalid symbols")

--- a/services/search/tests/routes/test_filter.py
+++ b/services/search/tests/routes/test_filter.py
@@ -76,6 +76,9 @@ def index_file_location(ds: Dataset) -> Generator[str, None, None]:
         ("where", "\"col\".upper() = 'A'"),
         ("where", '("col"."subcol").upper() = \'A\''),
         ("where", "\"col\".replace('a', 'A') = 'A'"),
+        ("where", "\"col\".lower() = 'a'"),
+        ("where", '"col".len() > 2'),
+        ("where", '"col".length() > 2'),
         ("orderby", ""),
         ("orderby", '"A"'),
         ("orderby", '"A" DESC'),
@@ -108,6 +111,23 @@ def test_validate_query_parameter_raises_on_sql_injection(
     ],
 )
 def test_validate_query_parameter_raises_on_system_functions(
+    parameter_name: Literal["where", "orderby"], parameter_value: str
+) -> None:
+    with pytest.raises(InvalidParameterError):
+        validate_query_parameter(parameter_value, parameter_name)
+
+
+@pytest.mark.parametrize(
+    "parameter_name, parameter_value",
+    [
+        ("where", "\"text\".read_text() = '1'"),
+        ("where", "\"meta\".read_blob('/proc/self/environ') IS NOT NULL"),
+        ("where", "\"col\".getenv('FOO') = 'bar'"),
+        ("where", "\"col\".sniff_csv() = 'a'"),
+        ("orderby", '"col".read_text()'),
+    ],
+)
+def test_validate_query_parameter_raises_on_chained_functions(
     parameter_name: Literal["where", "orderby"], parameter_value: str
 ) -> None:
     with pytest.raises(InvalidParameterError):


### PR DESCRIPTION
## Context

`validate_query_parameter` is the first of two layers protecting the DuckDB
query built by `/filter`. The second is the engine sandbox set up in
`duckdb_connect`: `allowed_paths`, `enable_external_access=false` and
`lock_configuration=true`.

The grammar the first layer enforced had drifted wide enough that it was no
longer contributing much. `SQL_MATCH_FUNC` was `[a-z_]+\(...\)`, so **any**
lowercase function name chained onto a column reference was accepted:

```
where="col".read_text() = '1'
where="col".read_blob('/proc/self/environ') IS NOT NULL
```

Both pass validation today and are handed to DuckDB. The sandbox refuses the
file access, so they fail rather than return data, which is why this is a
hardening change and not an incident. But the outcome was resting entirely on
the second layer.

Two smaller issues in the same grammar:

- `SQL_MATCH_OP` was a `+`-repeated character class that also matched spaces
  and `*`, so it accepted long operator-like runs that were never intended.
- `SQL_MATCH_NUMBER` was `[0-9][0-9\.]*`, which rejects negative and leading-dot
  numbers while accepting malformed ones such as `1.2.3`.

## Changes

- restrict chained functions to an allowlist: `len`, `length`, `lower`,
  `replace`, `upper`. These are the ones the endpoint documents and the ones
  the existing tests exercise.
- replace the operator character class with an explicit alternation.
- use `fullmatch` instead of `match`, and compile with `IGNORECASE` instead of
  spelling out both cases in every sub-pattern.
- accept signed and fractional numbers, reject malformed ones.
- log the length of `where` and `orderby` rather than their values, so
  caller-controlled text no longer lands verbatim in the application log.

## Tests

`test_validate_query_parameter` gains the remaining allowlisted functions, so
all five are covered. A new `test_validate_query_parameter_raises_on_chained_functions`
covers the chained forms that used to pass.