### PR TITLE
fix(chart): use ip target-type for prod ALB ingresses

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -272,7 +272,7 @@ ingress:
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:707930574880:certificate/134d1ed3-7ac1-481d-b2e4-31e17fbacb28
     alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod"
     alb.ingress.kubernetes.io/tags: "Env=prod,Project=datasets-server,Terraform=true"
-    alb.ingress.kubernetes.io/target-node-labels: role-datasets-server=true
+    alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/healthcheck-path: "/healthcheck"
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80, "HTTPS": 443}]'
     alb.ingress.kubernetes.io/scheme: "internal"
@@ -306,7 +306,6 @@ admin:
     enabled: true
     annotations:
       alb.ingress.kubernetes.io/group.order: "1"
-      alb.ingress.kubernetes.io/target-node-labels: role-datasets-server=true
       alb.ingress.kubernetes.io/actions.metrics-unauthorized: '{"type":"fixed-response","fixedResponseConfig":{"contentType":"text/plain","statusCode":"401","messageBody":"401 Unauthorized"}}'
   ingressInternal:
     enabled: true
@@ -343,7 +342,6 @@ api:
   ingress:
     enabled: true
     annotations:
-      alb.ingress.kubernetes.io/target-node-labels: role-datasets-server-api=true
       alb.ingress.kubernetes.io/actions.openapi-redirect: '{"Type":"redirect","RedirectConfig":{"Host":"raw.githubusercontent.com","Path":"/huggingface/dataset-viewer/main/docs/source/openapi.json","Port":"443","Protocol":"HTTPS","Query":"#{query}","StatusCode":"HTTP_302"}}'
       alb.ingress.kubernetes.io/actions.metrics-unauthorized: '{"type":"fixed-response","fixedResponseConfig":{"contentType":"text/plain","statusCode":"401","messageBody":"401 Unauthorized"}}'
   ingressInternal:
@@ -380,7 +378,6 @@ rows:
     enabled: true
     annotations:
       alb.ingress.kubernetes.io/group.order: "2"
-      alb.ingress.kubernetes.io/target-node-labels: role-datasets-server-rows=true
   ingressInternal:
     enabled: true
     annotations:
@@ -416,9 +413,7 @@ search:
     enabled: true
     annotations:
       alb.ingress.kubernetes.io/group.order: "3"
-      alb.ingress.kubernetes.io/target-node-labels: role-datasets-server-search=true
       alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=300
-      alb.ingress.kubernetes.io/target-type: ip
   ingressInternal:
     enabled: true
     annotations:
@@ -453,7 +448,6 @@ sseApi:
     enabled: false
     annotations:
       alb.ingress.kubernetes.io/group.order: "4"
-      alb.ingress.kubernetes.io/target-node-labels: role-datasets-server=true
   ingressInternal:
     enabled: true
     annotations:
@@ -607,7 +601,6 @@ webhook:
     enabled: true
     annotations:
       alb.ingress.kubernetes.io/group.order: "5"
-      alb.ingress.kubernetes.io/target-node-labels: role-datasets-server-webhook=true
   ingressInternal:
     enabled: true
     annotations:


### PR DESCRIPTION
## Problem

The prod ingress annotations set no `alb.ingress.kubernetes.io/target-type`, so the AWS Load Balancer Controller defaulted to `instance`. That registers the EC2 nodes (via NodePort) in the target groups instead of the pods, which makes the whole node look internet-facing.

## Change

Set `target-type: ip` on the global `ingress.annotations` so the ALB targets pod IPs, and drop the seven `target-node-labels` annotations, which only apply to the `instance` target type and become inert. The per-service `target-type: ip` on `search` is now redundant and removed too.

`helm template` renders all 11 ingresses with `target-type: ip` and no `target-node-labels`. Diffing the rendered annotations before and after shows only those two keys changing — no other annotation is touched.

## Rollout notes

- Switching target type makes the controller recreate the target groups and reattach the listener rules, so expect a short draining window.
- The `search` ingress already ran in `ip` mode on these same ALBs, and all six services expose `http:80 -> 8080`, so the switch is uniform and the health check path (`/healthcheck`) is unchanged.
- The `datasets-server` namespace needs the `elbv2.k8s.aws/pod-readiness-gate-inject: enabled` label so pods stay unready until they are registered in the target group. That label is missing today and is added in a companion infra PR, which should be applied **before** this chart change.
