### PR TITLE
feat(chart): reach S3 with the pod role in prod and staging

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -123,7 +123,7 @@ mongodb:
 s3:
   regionName: "us-east-1"
   # when true, drop static S3 credentials and rely on the ServiceAccount IRSA role
-  useIrsa: false
+  useIrsa: true
 
 common:
   # URL of the HuggingFace Hub

--- a/chart/env/staging.yaml
+++ b/chart/env/staging.yaml
@@ -132,6 +132,10 @@ cachedAssets:
   storageRoot: "hf-datasets-server-statics-staging/cached-assets"
   storageProtocol: "s3"
 
+s3:
+  # when true, drop static S3 credentials and rely on the ServiceAccount IRSA role
+  useIrsa: true
+
 # --- jobs (pre-install/upgrade hooks) ---
 
 mongodbMigration:


### PR DESCRIPTION
Two lines: `s3.useIrsa` goes to `true` for prod and staging.

## Why now

The chart has carried `s3.useIrsa` since IRSA support landed, and `_envS3.tpl` already drops the static pair when it is on. Both environments were still on `false`, so the containers took their credentials from `hf-datasets-server-statics-user` and `-staging-user`.

Those keys were created **2023-10-11** and **2023-09-28** and were never rotated after the July incident, which came in through datasets-server.

What was missing was on the AWS side, not here. Both ServiceAccounts are annotated with a role that carried **no policy at all**:

| Environment | ServiceAccount | Role | Fixed by |
|---|---|---|---|
| prod | `prod-datasets-server` | `datasets-prod-us-east-1-datasets-server-mongodb` | infra#4140 |
| staging | `datasets-server-staging` | `hub-ephemeral-datasets-server-mongodb` | infra#4141 |

Both roles now mirror their user's grants exactly.

Worth noting for staging: the RW policy was attached to `hub-ephemeral-datasets-server`, a role created in July whose `RoleLastUsed` is null. It trusts a ServiceAccount no deployment uses, so it had never been assumed once. The policy went onto the role the pods actually assume instead.

## Evidence

Rendering each environment's values:

| | `S3_ACCESS_KEY_ID` before | after |
|---|---|---|
| prod | 10 | **0** |
| staging | 7 | **0** |

`S3_USE_IRSA` is `"true"` in every container, and `S3_REGION_NAME` still resolves to `us-east-1` in staging, which only sets `useIrsa` and inherits the rest.

## Order

This has to land and roll out before the credentials are removed, not after. While `useIrsa` is false the pods need the key; once it is true they ignore it, and only then is deleting it safe.

After the rollout: drop `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from the `datasets-server` Infisical project and from the staging secret, then delete both IAM users and their keys.

## Not in this PR

The e2e tests are a separate matter: they run on GitHub hosted runners with no pod role, so they need `role-to-assume` over OIDC. The role exists (`dataset-viewer-e2e`, infra#4141). Doing it needs care, since `docker-compose.yml` forwards only `S3_*` to the containers and nothing in the config carries a session token, which a temporary credential always has.