### PR TITLE
feat(ci): assume a role for the e2e fixtures instead of a static key

### DIFF
--- a/.github/workflows/_e2e_tests.yml
+++ b/.github/workflows/_e2e_tests.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  # minting the OIDC token the AWS role is assumed with
+  id-token: write
 
 env:
   python-version: 3.14.5
@@ -26,6 +28,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Assume the AWS role that writes the test fixtures
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::707930574880:role/dataset-viewer-e2e
+          aws-region: us-east-1
       - name: Build and launch the services (no cache)
         env:
           ADMIN_UVICORN_NUM_WORKERS: "1"
@@ -66,8 +73,9 @@ jobs:
           CACHED_ASSETS_BASE_URL: "https://datasets-server-test.us.dev.moon.huggingface.tech/cached-assets"
           CACHED_ASSETS_STORAGE_PROTOCOL: "s3"
           CACHED_ASSETS_STORAGE_ROOT: "hf-datasets-server-statics-test/cached-assets"
-          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          # The step above exported AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and
+          # AWS_SESSION_TOKEN; docker-compose forwards them to the containers.
+          S3_USE_IRSA: "true"
           S3_REGION_NAME: "us-east-1"
           CLOUDFRONT_KEY_PAIR_ID: "K1MTLUUQ6YN2UZ"
           CLOUDFRONT_PRIVATE_KEY: ${{ secrets.CLOUDFRONT_PRIVATE_KEY }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,4 +42,8 @@ jobs:
       working-directory: e2e
   e2e-tests:
     uses: ./.github/workflows/_e2e_tests.yml
+    permissions:
+      contents: read
+      # a reusable workflow cannot widen this, the caller has to grant it
+      id-token: write
     secrets: inherit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,16 @@ x-common-env: &common-env
   CACHED_ASSETS_BASE_URL: ${CACHED_ASSETS_BASE_URL} # <- must be set, no default value. If local, set to work with the reverse-proxy, like http://localhost:${PORT_REVERSE_PROXY-8000}/cached-assets
   CACHED_ASSETS_STORAGE_ROOT: ${CACHED_ASSETS_STORAGE_ROOT}
   CACHED_ASSETS_STORAGE_PROTOCOL: ${CACHED_ASSETS_STORAGE_PROTOCOL}
-  # S3
+  # S3. With S3_USE_IRSA the static pair is ignored and botocore resolves on its
+  # own, from the AWS_* variables below in CI, where the runner assumes a role
+  # over OIDC and its credentials are temporary, hence the session token.
   S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
   S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
   S3_REGION_NAME: ${S3_REGION_NAME}
+  S3_USE_IRSA: ${S3_USE_IRSA-false}
+  AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID-}
+  AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY-}
+  AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN-}
   # cloudfront (for signed URLs)
   CLOUDFRONT_EXPIRATION_SECONDS: ${CLOUDFRONT_EXPIRATION_SECONDS}
   CLOUDFRONT_KEY_PAIR_ID: ${CLOUDFRONT_KEY_PAIR_ID}


### PR DESCRIPTION
Last of the three `hf-datasets-server-statics` identities, after prod and staging in #3418 and #3419.

## Why this one is different

The e2e tests write fixtures to `hf-datasets-server-statics-test` with `hf-datasets-server-statics-test-user`, whose secret sits in this repository as `S3_ACCESS_KEY_ID`.

Unlike the pods, the runners are GitHub hosted, so there is no role for them to fall back on. OIDC is the only way off that key.

I confirmed the consumer from the bucket's own access logs rather than guessing: the calls come from `172.172.206.44`, a public Azure address, which is a GitHub hosted runner.

## How it works

The runner assumes `dataset-viewer-e2e` (created in infra#4141, subjects pinned to `refs/heads/main` and `pull_request` since this repository is public), and `docker-compose.yml` forwards the resulting `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` to the containers. The session token matters: an assumed role always carries one, and a presigned or signed request without it is rejected.

`S3_USE_IRSA: "true"` then makes `S3Config.from_env` skip the static pair and leave botocore to resolve, which is the same path production has run since #3418.

## One trap avoided

Simply not setting `S3_ACCESS_KEY_ID` would not have worked. Compose turns an unset variable into an **empty string**, and `resolve_secret` returns `env.str(...)` unchanged, so botocore would receive `""` as if it were a real key and fail. Reusing the flag sidesteps that entirely.

## Permissions

`id-token: write` is granted twice on purpose: on the reusable workflow, and on the calling job in `e2e.yml`. A reusable workflow cannot widen what its caller gives it, so the caller has to grant it or the token cannot be minted.

## After this

Delete `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` from the repository secrets, then the IAM user and its key.

With the three of them gone, the hub account drops from 14 active access keys to 11.