### PR TITLE
fix(chart): loosen the ALB health check on the prod search ingresses

### DIFF
--- a/chart/env/prod.yaml
+++ b/chart/env/prod.yaml
@@ -414,6 +414,9 @@ search:
     annotations:
       alb.ingress.kubernetes.io/group.order: "3"
       alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=300
+      # /healthcheck shares the 2 uvicorn workers with search queries, so it blocks under load
+      alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "10"
+      alb.ingress.kubernetes.io/unhealthy-threshold-count: "5"
   ingressInternal:
     enabled: true
     annotations:
@@ -422,6 +425,9 @@ search:
       alb.ingress.kubernetes.io/scheme: "internal"
       alb.ingress.kubernetes.io/load-balancer-name: "datasets-server-prod-int"
       alb.ingress.kubernetes.io/group.name: "datasets-server-internal"
+      # /healthcheck shares the 2 uvicorn workers with search queries, so it blocks under load
+      alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "10"
+      alb.ingress.kubernetes.io/unhealthy-threshold-count: "5"
   resources:
     requests:
       cpu: 1


### PR DESCRIPTION
## Problem

While watching the `target-type: ip` rollout (#3417), the `search` targets flapped between `healthy` and `unhealthy` in both ALBs, reaching **2 of 3 targets unhealthy at the same time**, with `reason=Target.Timeout / Request timed out`:

```
k8s-datasets-proddata-3acd5c6aba  (prod-datasets-server-search)
  10.23.78.246:8080  healthy
  10.23.19.21:8080   healthy
  10.23.12.165:8080  unhealthy  reason=Target.Timeout  Request timed out
```

The affected pods stayed `Ready` in Kubernetes throughout, never restarted, and recovered on their own.

## Cause

`search` runs 2 uvicorn workers (`uvicornNumWorkers: "2"`, deliberately capped to avoid OOM) and serves `/healthcheck` from the same workers that run the search queries. When both workers are busy — loading duckdb indexes, fetching parquet metadata from the Hub — the health check cannot be answered.

The target group allowed `HealthCheckTimeoutSeconds=5` with `UnhealthyThresholdCount=2` at `HealthCheckIntervalSeconds=15`, so roughly 30s of load was enough to pull a pod out of rotation. Its traffic then moved to the remaining pods, making them more likely to time out in turn. **The flapping is self-reinforcing**, and with only 3 replicas all three could be evicted, which would return 503 on the search routes.

Kubernetes is far more tolerant on the very same endpoint: `failureThreshold: 30` × `periodSeconds: 5` = 150s. That mismatch is why the ALB was evicting pods the kubelet still considered healthy.

## Change

On both the public and internal `search` ingresses:

```yaml
alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "10"
alb.ingress.kubernetes.io/unhealthy-threshold-count: "5"
```

The interval stays at 15s, so a busy pod now has ~75s before the ALB pulls it, while a genuinely dead pod is still removed within 75s. The timeout stays below the interval, as the ALB requires.

`helm template` confirms only the two `search` ingresses carry the new annotations; the other 9 are untouched. `helm lint` passes on both prod and staging values.

## Scope

This does not remove the underlying contention on the 2 uvicorn workers — it stops a transient slowdown from turning into lost capacity. Raising `uvicornNumWorkers` or the replica count would address the cause, but both interact with the 250Gi memory envelope and belong in a separate change.

Not applied to staging: the flapping is a production-load phenomenon, and staging's search runs a different profile.
